### PR TITLE
[ZoL#22] Implement DKIOCFLUSHWRITECACHE vdev ioctl command

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -53,6 +53,11 @@ To try zpool and zfs commands, start `cmd/tgt/tgt` binary with `sudo` and
 leave it running. Now zpool and zfs commands from cmd/ directory can be
 used in usual way.
 
+# Caveats
+
+Disk write cache must be disabled for any device not managed by linux
+sd driver. Cache flush is not supported for other drivers than sd.
+
 # Contributing
 Make sure to run cstyle on your changes before you submit a pull request:
 


### PR DESCRIPTION
As noted in the code, this flush command works only for SCSI drives controlled by sd driver and regarding synchronicity of flush command, I tested performance with synchronous and asynchronous (using taskq) flush and with sync workloads the performance penalty is 25% when using async and only 15% when using sync. So we will be calling flush synchronously in zio pipeline. So just to highlight it, for drives which support SCSI SYNCHRONIZE CACHE command we sacrifice 15% of performance for sync workloads, but that is understandable as we have more work to do in such case.