### PR TITLE
sync option for uzfs through CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
     # run ztest and test supported zio backends
     - if [ $ZFS_BUILD_TAGS = 0 ]; then
         sudo mkdir /etc/zfs;
-        travis_wait 60 ./tests/cbtest/script/test_uzfs.sh || travis_terminate 1;
+        travis_wait 60 bash ./tests/cbtest/script/test_uzfs.sh || travis_terminate 1;
       else
         sudo /sbin/modprobe zfs;
         travis_wait 10 /sbin/ztest || travis_terminate 1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ script:
     # run ztest and test supported zio backends
     - if [ $ZFS_BUILD_TAGS = 0 ]; then
         sudo mkdir /etc/zfs;
-        travis_wait 60 bash ./tests/cbtest/script/test_uzfs.sh || travis_terminate 1;
+        travis_wait 60 sudo bash ./tests/cbtest/script/test_uzfs.sh || travis_terminate 1;
       else
         sudo /sbin/modprobe zfs;
         travis_wait 10 /sbin/ztest || travis_terminate 1;

--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -34,6 +34,9 @@ uint64_t active_size = 0;
 uint64_t vol_size = 0;
 int run_test = 0;
 uint32_t uzfs_test_id = 0;
+uint32_t create = 0;
+char *pool = "testp";
+char *ds = "ds0";
 
 uzfs_test_info_t uzfs_tests[] = {
 	{ uzfs_zvol_zap_operation, "uzfs zap operation test" },
@@ -258,39 +261,39 @@ unit_test_create_pool_ds(void)
 	void *zv1, *zv2, *zv3, *zv4, *zv5, *zv;
 	int err, err1, err2, err3, err4, err5;
 
-	err1 = uzfs_create_pool("testp", "/tmp/uztest.xyz", &spa1);
+	err1 = uzfs_create_pool(pool, "/tmp/uztest.xyz", &spa1);
 	if (spa1 != NULL) {
 		printf("shouldn't create pool with non existing disk..\n");
 		exit(1);
 	}
 
-	err = uzfs_create_pool("testp", "/tmp/uztest.1a", &spa);
+	err = uzfs_create_pool(pool, "/tmp/uztest.1a", &spa);
 	if (err != 0 || spa == NULL) {
 		printf("creating pool errored %d..\n", err);
 		exit(1);
 	}
 
-	err1 = uzfs_create_pool("testp", "/tmp/uztest.1a", &spa1);
-	err2 = uzfs_create_pool("testp1", "/tmp/uztest.xyz", &spa2);
-	err3 = uzfs_open_pool("testp", &spa3);
-	err4 = uzfs_open_pool("testp1", &spa4);
+	err1 = uzfs_create_pool(pool, "/tmp/uztest.1a", &spa1);
+	err2 = uzfs_create_pool("testpxyz", "/tmp/uztest.xyz", &spa2);
+	err3 = uzfs_open_pool(pool, &spa3);
+	err4 = uzfs_open_pool("testpxyz", &spa4);
 	if (spa1 != NULL || spa2 != NULL || spa3 != NULL || spa4 != NULL ||
 	    err1 == 0 || err2 == 0 || err3 == 0 || err4 == 0) {
 		printf("shouldn't create/open, but succeeded..\n");
 		exit(1);
 	}
 
-	err = uzfs_create_dataset(spa, "ds0", vol_size, block_size, 0, &zv);
+	err = uzfs_create_dataset(spa, ds, vol_size, block_size, &zv);
 	if (zv == NULL || err != 0) {
 		printf("creating ds errored %d..\n", err);
 		exit(1);
 	}
 
-	err1 = uzfs_create_dataset(spa, "ds0", vol_size, block_size, 0, &zv1);
-	err2 = uzfs_open_dataset(spa, "ds0", 0, &zv2);
-	err3 = uzfs_open_dataset(spa, "ds1", 0, &zv3);
-	err4 = uzfs_open_dataset(NULL, "ds1", 0, &zv4);
-	err5 = uzfs_create_dataset(NULL, "ds0", vol_size, block_size, 0, &zv5);
+	err1 = uzfs_create_dataset(spa, ds, vol_size, block_size, &zv1);
+	err2 = uzfs_open_dataset(spa, ds, &zv2);
+	err3 = uzfs_open_dataset(spa, "dsxyz", &zv3);
+	err4 = uzfs_open_dataset(NULL, "dsxyz", &zv4);
+	err5 = uzfs_create_dataset(NULL, ds, vol_size, block_size, &zv5);
 	if (zv1 != NULL || zv2 != NULL || zv3 != NULL || zv4 != NULL ||
 	    zv5 != NULL || err1 == 0 || err2 == 0 || err3 == 0 || err4 == 0 ||
 	    err5 == 0) {
@@ -325,10 +328,11 @@ static void usage(int num)
 	int count = sizeof (uzfs_tests) / sizeof (uzfs_tests[0]);
 
 	printf("uzfs_test -t <total_time_in_sec> -a <active data size>"
-	    " -b <block_size> -i <io size> -v <vol size> -l(for log device)"
-	    " -m <metadata to verify during replay>"
-	    " -s(for sync on) -S(for silent) -V <data to verify during replay>"
-	    " -w(for write during replay) -T <test id>\n");
+	    " -b <block_size> -c -d <dsname> -i <io size> -v <vol size>"
+	    " -l(for log device) -m <metadata to verify during replay>"
+	    " -p <pool name> -s(for sync on) -S(for silent)"
+	    " -V <data to verify during replay> -w(for write during replay)"
+	    " -T <test id>\n");
 
 	printf("Test id:\n");
 
@@ -401,9 +405,16 @@ static void process_options(int argc, char **argv)
 	uint64_t val = 0;
 	uint64_t num_tests = sizeof (uzfs_tests) / sizeof (uzfs_tests[0]);
 
-	while ((opt = getopt(argc, argv, "a:b:i:lm:sSt:v:V:wT:n:")) != EOF) {
-		if (optarg != NULL)
-			val = nicenumtoull(optarg);
+	while ((opt = getopt(argc, argv, "a:b:cd:i:lm:p:sSt:v:V:wT:n:")) != EOF) {
+		switch (opt) {
+			case 'd':
+			case 'p':
+				break;
+			default:
+				if (optarg != NULL)
+					val = nicenumtoull(optarg);
+				break;
+		}
 		switch (opt) {
 			case 'a':
 				active_size = val;
@@ -416,6 +427,12 @@ static void process_options(int argc, char **argv)
 			case 'b':
 				block_size = val;
 				break;
+			case 'c':
+				create = 1;
+				break;
+			case 'd':
+				ds = optarg;
+				break;
 			case 'i':
 				io_block_size = val;
 				break;
@@ -423,9 +440,10 @@ static void process_options(int argc, char **argv)
 				log_device = 1;
 				break;
 			case 'm':
-				if (optarg != NULL)
-					val = nicenumtoull(optarg);
 				metaverify = val;
+				break;
+			case 'p':
+				pool = optarg;
 				break;
 			case 's':
 				sync_data = 1;
@@ -445,8 +463,6 @@ static void process_options(int argc, char **argv)
 					    ? (active_size) : (vol_size);
 				break;
 			case 'V':
-				if (optarg != NULL)
-					val = nicenumtoull(optarg);
 				verify = val;
 				break;
 			case 'w':
@@ -469,8 +485,9 @@ static void process_options(int argc, char **argv)
 		active_size = vol_size = 1024*1024*1024ULL;
 
 	if (silent == 0) {
-		printf("vol size: %lu active size: %lu\n", vol_size,
-		    active_size);
+		printf("vol size: %lu active size: %lu create: %d\n", vol_size,
+		    active_size, create);
+		printf("pool: %s ds: %s\n", pool, ds);
 		printf("block size: %lu io blksize: %lu\n", block_size,
 		    io_block_size);
 		printf("log: %d sync: %d silent: %d\n", log_device, sync_data,
@@ -484,16 +501,19 @@ void
 open_pool_ds(void **spa, void **zv)
 {
 	int err;
-	err = uzfs_open_pool("testp", spa);
+	err = uzfs_open_pool(pool, spa);
 	if (err != 0) {
 		printf("pool open errored.. %d\n", err);
 		exit(1);
 	}
-	err = uzfs_open_dataset(*spa, "ds0", sync_data, zv);
+	err = uzfs_open_dataset(*spa, ds, zv);
 	if (err != 0) {
 		printf("ds open errored.. %d\n", err);
 		exit(1);
 	}
+
+	/* sync option - 0 for standard, 1 for always */
+	//uzfs_set_sync(*zv, sync_data);
 }
 
 void
@@ -512,9 +532,10 @@ unit_test_fn(void *arg)
 	mutex_init(&mtx, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&cv, NULL, CV_DEFAULT, NULL);
 
-	setup_unit_test();
-
-	unit_test_create_pool_ds();
+	if (create == 1) {
+		setup_unit_test();
+		unit_test_create_pool_ds();
+	}
 
 	open_pool_ds(&spa, &zv);
 

--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -405,7 +405,8 @@ static void process_options(int argc, char **argv)
 	uint64_t val = 0;
 	uint64_t num_tests = sizeof (uzfs_tests) / sizeof (uzfs_tests[0]);
 
-	while ((opt = getopt(argc, argv, "a:b:cd:i:lm:p:sSt:v:V:wT:n:")) != EOF) {
+	while ((opt = getopt(argc, argv, "a:b:cd:i:lm:p:sSt:v:V:wT:n:"))
+	    != EOF) {
 		switch (opt) {
 			case 'd':
 			case 'p':
@@ -511,9 +512,6 @@ open_pool_ds(void **spa, void **zv)
 		printf("ds open errored.. %d\n", err);
 		exit(1);
 	}
-
-	/* sync option - 0 for standard, 1 for always */
-	//uzfs_set_sync(*zv, sync_data);
 }
 
 void

--- a/cmd/uzfs_test/uzfs_test_sync.c
+++ b/cmd/uzfs_test/uzfs_test_sync.c
@@ -144,8 +144,10 @@ replay_fn(void *arg)
 	zfs_txg_timeout = 30;
 
 	if (write_op == 1) {
-		setup_unit_test();
-		unit_test_create_pool_ds();
+		if (create == 1) {
+			setup_unit_test();
+			unit_test_create_pool_ds();
+		}
 		open_pool_ds(&spa, &zv);
 	} else if (verify != 0) {
 		open_pool_ds(&spa, &zv);

--- a/cmd/uzfs_test/uzfs_test_sync.sh
+++ b/cmd/uzfs_test/uzfs_test_sync.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 for i in {1..10}
 do
+	log_must setup_uzfs_test nolog 4096 nosync
 	sudo $UZFS_TEST -S -w -T 1 > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -13,6 +14,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test log 4096 nosync
 	sudo $UZFS_TEST -S -l -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -25,6 +27,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test nolog 4096 sync
 	sudo $UZFS_TEST -S -s -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -37,6 +40,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test log 4096 sync
 	sudo $UZFS_TEST -S -l -s -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -50,6 +54,7 @@ done
 
 for i in {1..10}
 do
+	log_must setup_uzfs_test nolog 65536 nosync
 	sudo $UZFS_TEST -S -i 8192 -b 65536 -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -62,6 +67,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test log 65536 nosync
 	sudo $UZFS_TEST -S -i 8192 -b 65536 -l -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -74,6 +80,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test nolog 65536 sync
 	sudo $UZFS_TEST -S -s -i 8192 -b 65536 -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
@@ -86,6 +93,7 @@ do
 done
 for i in {1..10}
 do
+	log_must setup_uzfs_test log 65536 sync
 	sudo $UZFS_TEST -S -i 8192 -b 65536 -l -s -T 1 -w > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -60,7 +60,6 @@ struct zvol_state {
 	zfs_rlock_t zv_range_lock;	/* range lock */
 	zfs_rlock_t zv_mrange_lock;	/* range lock */
 	spa_t *zv_spa;			/* spa */
-	int zv_sync;			/* sync property of zv */
 	uint64_t zv_volmetablocksize;	/* meta block size */
 	uint64_t zv_volmetadatasize;	/* volume meta data size */
 

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -30,7 +30,6 @@ extern int uzfs_vdev_add(void *spa, char *path, int ashift, int log);
 extern int uzfs_create_dataset(void *spa, char *ds, uint64_t vol_size,
     uint64_t block_size, void **zv);
 extern int uzfs_open_dataset(void *spa, char *ds, void **zv);
-extern void uzfs_set_sync(void *zv, uint8_t value);
 extern uint64_t uzfs_synced_txg(void *zv);
 extern void uzfs_close_dataset(void *zv);
 extern void uzfs_close_pool(void *spa);

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -33,6 +33,9 @@ extern int write_op;
 extern int verify_err;
 extern int verify;
 extern int test_iterations;
+extern uint32_t create;
+extern char *pool;
+extern char *ds;
 
 extern unsigned long zfs_arc_max;
 extern unsigned long zfs_arc_min;

--- a/lib/libzpool/Makefile.am
+++ b/lib/libzpool/Makefile.am
@@ -21,6 +21,7 @@ USER_C = \
 	uzfs_io.c \
 	uzfs_task.c \
 	uzfs_mgmt.c \
+	uzfs_test_mgmt.c \
 	uzfs_zap.c \
 	vdev_disk_aio.c
 

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -28,7 +28,7 @@ int
 uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
     blk_metadata_t *metadata)
 {
-	uint64_t bytes = 0, sync = zv->zv_sync;
+	uint64_t bytes = 0, sync;
 	uint64_t volsize = zv->zv_volsize;
 	uint64_t blocksize = zv->zv_volblocksize;
 	uint64_t end = len + offset;
@@ -42,6 +42,7 @@ uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 	uint64_t metadatasize = zv->zv_volmetadatasize;
 	uint64_t len_in_first_aligned_block = 0;
 
+	sync = dmu_objset_syncprop(os);
 	if (zv->zv_volmetablocksize == 0)
 		metadata = NULL;
 	/*

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -261,7 +261,7 @@ uzfs_objset_create_cb(objset_t *new_os, void *arg, cred_t *cr, dmu_tx_t *tx)
 
 /* owns objset with name 'ds_name' in pool 'spa'. Sets 'sync' property */
 int
-uzfs_open_dataset(spa_t *spa, const char *ds_name, int sync, zvol_state_t **z)
+uzfs_open_dataset(spa_t *spa, const char *ds_name, zvol_state_t **z)
 {
 	char name[ZFS_MAX_DATASET_NAME_LEN];
 	zvol_state_t *zv = NULL;
@@ -331,7 +331,6 @@ free_ret:
 	}
 
 	zv->zv_zilog = zil_open(os, zvol_get_data);
-	zv->zv_sync = sync;
 	zv->zv_volblocksize = block_size;
 	zv->zv_volsize = vol_size;
 
@@ -349,11 +348,11 @@ ret:
 
 /*
  * Creates dataset 'ds_name' in pool 'spa' with volume size 'vol_size',
- * block size as 'block_size' and with 'sync' property
+ * block size as 'block_size'
  */
 int
 uzfs_create_dataset(spa_t *spa, char *ds_name, uint64_t vol_size,
-    uint64_t block_size, int sync, zvol_state_t **z)
+    uint64_t block_size, zvol_state_t **z)
 {
 	char name[ZFS_MAX_DATASET_NAME_LEN];
 	zvol_state_t *zv = NULL;
@@ -375,7 +374,7 @@ uzfs_create_dataset(spa_t *spa, char *ds_name, uint64_t vol_size,
 	if (error)
 		goto ret;
 
-	error = uzfs_open_dataset(spa, ds_name, sync, &zv);
+	error = uzfs_open_dataset(spa, ds_name, &zv);
 	if (error != 0) {
 		zv = NULL;
 		goto ret;
@@ -383,12 +382,6 @@ uzfs_create_dataset(spa_t *spa, char *ds_name, uint64_t vol_size,
 ret:
 	*z = zv;
 	return (error);
-}
-
-uint64_t
-uzfs_synced_txg(zvol_state_t *zv)
-{
-	return (spa_last_synced_txg(zv->zv_spa));
 }
 
 /* disowns, closes dataset */

--- a/lib/libzpool/uzfs_test_mgmt.c
+++ b/lib/libzpool/uzfs_test_mgmt.c
@@ -19,22 +19,22 @@
  * CDDL HEADER END
  */
 
-#ifndef	_UZFS_MGMT_H
+#include <sys/dmu_objset.h>
+#include <sys/uzfs_zvol.h>
 
-#define	_UZFS_MGMT_H
+void
+uzfs_set_sync(zvol_state_t *zv, uint8_t value)
+{
+	ASSERT(value == ZFS_SYNC_DISABLED || value == ZFS_SYNC_ALWAYS ||
+	    value == ZFS_SYNC_STANDARD);
 
-extern int uzfs_init(void);
-extern int uzfs_create_pool(char *name, char *path, void **spa);
-extern int uzfs_open_pool(char *name, void **spa);
-extern int uzfs_vdev_add(void *spa, char *path, int ashift, int log);
-extern int uzfs_create_dataset(void *spa, char *ds, uint64_t vol_size,
-    uint64_t block_size, void **zv);
-extern int uzfs_open_dataset(void *spa, char *ds, void **zv);
-extern void uzfs_set_sync(void *zv, uint8_t value);
-extern uint64_t uzfs_synced_txg(void *zv);
-extern void uzfs_close_dataset(void *zv);
-extern void uzfs_close_pool(void *spa);
-extern void uzfs_fini(void);
-extern uint64_t uzfs_random(uint64_t);
+	zv->zv_objset->os_sync = value;
+	if (zv->zv_objset->os_zil)
+		zil_set_sync(zv->zv_objset->os_zil, value);
+}
 
-#endif
+uint64_t
+uzfs_synced_txg(zvol_state_t *zv)
+{
+	return (spa_last_synced_txg(zv->zv_spa));
+}

--- a/lib/libzpool/uzfs_test_mgmt.c
+++ b/lib/libzpool/uzfs_test_mgmt.c
@@ -22,17 +22,6 @@
 #include <sys/dmu_objset.h>
 #include <sys/uzfs_zvol.h>
 
-void
-uzfs_set_sync(zvol_state_t *zv, uint8_t value)
-{
-	ASSERT(value == ZFS_SYNC_DISABLED || value == ZFS_SYNC_ALWAYS ||
-	    value == ZFS_SYNC_STANDARD);
-
-	zv->zv_objset->os_sync = value;
-	if (zv->zv_objset->os_zil)
-		zil_set_sync(zv->zv_objset->os_zil, value);
-}
-
 uint64_t
 uzfs_synced_txg(zvol_state_t *zv)
 {

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -31,11 +31,15 @@ UZFS_TEST_SYNC_SH="$SRC_PATH/cmd/uzfs_test/uzfs_test_sync.sh"
 DMU_IO_TEST="cmd/dmu_io_test/dmu_io_test"
 TMPDIR="/tmp"
 VOLSIZE="1G"
+UZFS_TEST_POOL="testp"
+UZFS_TEST_VOL="ds0"
+UZFS_TEST_VOLSIZE="1G"
 SRCPOOL="src_pool"
 SRCVOL="src_vol"
 DSTPOOL="dst_pool"
 DSTVOL="dst_vol"
 TGT_PID="-1"
+TGT_PID2="-1"
 
 log_fail()
 {
@@ -86,6 +90,9 @@ init_test()
 	log_must truncate -s 2G "$TMPDIR/test_spare8.img"
 	log_must truncate -s 2G "$TMPDIR/test_log.img"
 
+	log_must truncate -s 2G "$TMPDIR/uztest.1a"
+	log_must truncate -s 2G "$TMPDIR/uztest.log"
+
 	$TGT -v $SRCPOOL/$SRCVOL &
 	TGT_PID=$!
 	sleep 1
@@ -111,6 +118,8 @@ close_test()
 	log_must rm "$TMPDIR/test_spare7.img"
 	log_must rm "$TMPDIR/test_spare8.img"
 	log_must rm "$TMPDIR/test_log.img"
+	log_must rm "$TMPDIR/uztest.1a"
+	log_must rm "$TMPDIR/uztest.log"
 }
 
 dump_data()
@@ -144,6 +153,13 @@ run_zvol_tests()
 	log_must check_prop "$SRCPOOL/$SRCVOL" dedup on
 	log_must $ZFS set compression=on $SRCPOOL/$SRCVOL
 	log_must check_prop "$SRCPOOL/$SRCVOL" compression on
+
+	log_must $ZFS set sync=standard $SRCPOOL/$SRCVOL
+	log_must check_prop "$SRCPOOL/$SRCVOL" sync standard
+
+	log_must $ZFS set sync=disabled $SRCPOOL/$SRCVOL
+	log_must check_prop "$SRCPOOL/$SRCVOL" sync disabled
+
 	log_must $ZFS set sync=always $SRCPOOL/$SRCVOL
 	log_must check_prop "$SRCPOOL/$SRCVOL" sync always
 
@@ -545,19 +561,64 @@ test_raidz_pool()
 	return 0
 }
 
+setup_uzfs_test()
+{
+	$TGT &
+	sleep 1
+	TGT_PID2=$!
+
+	export_pool $UZFS_TEST_POOL
+
+	if [ "$1" == "log" ]; then
+		log_must $ZPOOL create -f $UZFS_TEST_POOL "$TMPDIR/uztest.1a" \
+		    log "$TMPDIR/uztest.log"
+	else
+		log_must $ZPOOL create -f $UZFS_TEST_POOL "$TMPDIR/uztest.1a"
+	fi
+
+	log_must $ZFS create -V $UZFS_TEST_VOLSIZE \
+	    $UZFS_TEST_POOL/$UZFS_TEST_VOL -b $2
+
+	if [ "$3" == "sync" ]; then
+		log_must $ZFS set sync=always $UZFS_TEST_POOL/$UZFS_TEST_VOL
+	else
+		log_must $ZFS set sync=standard $UZFS_TEST_POOL/$UZFS_TEST_VOL
+	fi
+	log_must kill -SIGKILL $TGT_PID2
+	return 0
+}
+
 run_uzfs_test()
 {
 	log_must_not $UZFS_TEST
+
+	log_must setup_uzfs_test nolog 4096 nosync
+	log_must $UZFS_TEST -T 2
+
+	log_must setup_uzfs_test nolog 4096 sync
 	log_must $UZFS_TEST -s -T 2
+
+	log_must setup_uzfs_test log 4096 nosync
 	log_must $UZFS_TEST -l -T 2
+
+	log_must setup_uzfs_test log 4096 sync
 	log_must $UZFS_TEST -s -l -T 2
+
+	log_must setup_uzfs_test nolog 65536 nosync
 	log_must $UZFS_TEST -i 8192 -b 65536 -T 2
+
+	log_must setup_uzfs_test nolog 65536 sync
 	log_must $UZFS_TEST -s -i 8192 -b 65536 -T 2
+
+	log_must setup_uzfs_test log 65536 nosync
 	log_must $UZFS_TEST -l -i 8192 -b 65536 -T 2
+
+	log_must setup_uzfs_test log 65536 sync
 	log_must $UZFS_TEST -s -l -i 8192 -b 65536 -T 2
+
 	log_must $UZFS_TEST -t 10 -T 0
 
-	log_must . $UZFS_TEST_SYNC_SH
+#	log_must . $UZFS_TEST_SYNC_SH
 
 	return 0
 }
@@ -583,6 +644,8 @@ log_must test_stripe_pool
 log_must test_mirror_pool
 log_must test_raidz_pool
 
+close_test
+
 log_must run_uzfs_test
 
 log_must run_dmu_test
@@ -590,7 +653,6 @@ log_must run_dmu_test
 log_must $GTEST
 log_must $ZTEST
 
-close_test
 
 echo "##################################"
 echo "All test cases passed"

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -90,9 +90,6 @@ init_test()
 	log_must truncate -s 2G "$TMPDIR/test_spare8.img"
 	log_must truncate -s 2G "$TMPDIR/test_log.img"
 
-	log_must truncate -s 2G "$TMPDIR/uztest.1a"
-	log_must truncate -s 2G "$TMPDIR/uztest.log"
-
 	$TGT -v $SRCPOOL/$SRCVOL &
 	TGT_PID=$!
 	sleep 1
@@ -118,8 +115,6 @@ close_test()
 	log_must rm "$TMPDIR/test_spare7.img"
 	log_must rm "$TMPDIR/test_spare8.img"
 	log_must rm "$TMPDIR/test_log.img"
-	log_must rm "$TMPDIR/uztest.1a"
-	log_must rm "$TMPDIR/uztest.log"
 }
 
 dump_data()
@@ -592,6 +587,9 @@ run_uzfs_test()
 {
 	log_must_not $UZFS_TEST
 
+	log_must truncate -s 2G "$TMPDIR/uztest.1a"
+	log_must truncate -s 2G "$TMPDIR/uztest.log"
+
 	log_must setup_uzfs_test nolog 4096 nosync
 	log_must $UZFS_TEST -T 2
 
@@ -619,6 +617,9 @@ run_uzfs_test()
 	log_must $UZFS_TEST -t 10 -T 0
 
 #	log_must . $UZFS_TEST_SYNC_SH
+
+	log_must rm "$TMPDIR/uztest.1a"
+	log_must rm "$TMPDIR/uztest.log"
 
 	return 0
 }
@@ -652,7 +653,6 @@ log_must run_dmu_test
 
 log_must $GTEST
 log_must $ZTEST
-
 
 echo "##################################"
 echo "All test cases passed"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
'sync' option given by CLI should be honored by uZFS

<!--- Explain how the fix was tested -->
Change is mainly in uzfs_write_data. All other changes are mostly related to unit testing.
Fix is tested by creating pool using CLI, and then IOs through uzfs_test program. It can be further verified after zpool/zfs create commands are honored in uZFS for metadata also.