### PR TITLE
reduce number of threads for uzfs (#47)

### DIFF
--- a/include/sys/zfs_context.h
+++ b/include/sys/zfs_context.h
@@ -654,7 +654,7 @@ extern void delay(clock_t ticks);
 	} while (0);
 
 #define	max_ncpus	64
-#define	boot_ncpus	(sysconf(_SC_NPROCESSORS_ONLN))
+#define	boot_ncpus	(MIN(sysconf(_SC_NPROCESSORS_ONLN), max_ncpus))
 
 /*
  * Process priorities as defined by setpriority(2) and getpriority(2).

--- a/lib/libzpool/taskq.c
+++ b/lib/libzpool/taskq.c
@@ -29,6 +29,7 @@
  */
 
 #include <sys/zfs_context.h>
+#include <sys/prctl.h>
 
 int taskq_now;
 taskq_t *system_taskq;
@@ -219,6 +220,8 @@ taskq_thread(void *arg)
 	taskq_ent_t *t;
 	boolean_t prealloc;
 
+	prctl(PR_SET_NAME, tq->tq_name, 0, 0, 0);
+
 	mutex_enter(&tq->tq_lock);
 	while (tq->tq_flags & TASKQ_ACTIVE) {
 		if ((t = tq->tq_task.tqent_next) == &tq->tq_task) {
@@ -359,8 +362,8 @@ taskq_cancel_id(taskq_t *tq, taskqid_t id)
 void
 system_taskq_init(void)
 {
-	system_taskq = taskq_create("system_taskq", 64, maxclsyspri, 4, 512,
-	    TASKQ_DYNAMIC | TASKQ_PREPOPULATE);
+	system_taskq = taskq_create("system_taskq", boot_ncpus, maxclsyspri,
+	    4, 512, TASKQ_DYNAMIC | TASKQ_PREPOPULATE);
 	system_delay_taskq = taskq_create("delay_taskq", 4, maxclsyspri, 4,
 	    512, TASKQ_DYNAMIC | TASKQ_PREPOPULATE);
 }

--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -6589,8 +6589,8 @@ arc_init(void)
 	    offsetof(arc_prune_t, p_node));
 	mutex_init(&arc_prune_mtx, NULL, MUTEX_DEFAULT, NULL);
 
-	arc_prune_taskq = taskq_create("arc_prune", max_ncpus, defclsyspri,
-	    max_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
+	arc_prune_taskq = taskq_create("arc_prune", boot_ncpus, defclsyspri,
+	    boot_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 
 	arc_reclaim_thread_exit = B_FALSE;
 

--- a/module/zfs/dsl_pool.c
+++ b/module/zfs/dsl_pool.c
@@ -179,8 +179,8 @@ dsl_pool_open_impl(spa_t *spa, uint64_t txg)
 	mutex_init(&dp->dp_lock, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&dp->dp_spaceavail_cv, NULL, CV_DEFAULT, NULL);
 
-	dp->dp_iput_taskq = taskq_create("z_iput", max_ncpus, defclsyspri,
-	    max_ncpus * 8, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
+	dp->dp_iput_taskq = taskq_create("z_iput", boot_ncpus, defclsyspri,
+	    boot_ncpus, INT_MAX, TASKQ_PREPOPULATE | TASKQ_DYNAMIC);
 
 	return (dp);
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -143,9 +143,9 @@ static const char *const zio_taskq_types[ZIO_TASKQ_TYPES] = {
 const zio_taskq_info_t zio_taskqs[ZIO_TYPES][ZIO_TASKQ_TYPES] = {
 	/* ISSUE	ISSUE_HIGH	INTR		INTR_HIGH */
 	{ ZTI_ONE,	ZTI_NULL,	ZTI_ONE,	ZTI_NULL }, /* NULL */
-	{ ZTI_N(8),	ZTI_NULL,	ZTI_P(12, 8),	ZTI_NULL }, /* READ */
-	{ ZTI_BATCH,	ZTI_N(5),	ZTI_P(12, 8),	ZTI_N(5) }, /* WRITE */
-	{ ZTI_P(12, 8),	ZTI_NULL,	ZTI_ONE,	ZTI_NULL }, /* FREE */
+	{ ZTI_N(4),	ZTI_NULL,	ZTI_BATCH,	ZTI_NULL }, /* READ */
+	{ ZTI_BATCH,	ZTI_N(3),	ZTI_ONE,	ZTI_ONE  }, /* WRITE */
+	{ ZTI_P(2, 4),	ZTI_NULL,	ZTI_ONE,	ZTI_NULL }, /* FREE */
 	{ ZTI_ONE,	ZTI_NULL,	ZTI_ONE,	ZTI_NULL }, /* CLAIM */
 	{ ZTI_ONE,	ZTI_NULL,	ZTI_ONE,	ZTI_NULL }, /* IOCTL */
 };

--- a/module/zfs/vdev_file.c
+++ b/module/zfs/vdev_file.c
@@ -260,8 +260,9 @@ vdev_ops_t vdev_file_ops = {
 void
 vdev_file_init(void)
 {
-	vdev_file_taskq = taskq_create("z_vdev_file", MAX(boot_ncpus, 16),
-	    minclsyspri, boot_ncpus, INT_MAX, TASKQ_DYNAMIC);
+	/* file backend is used for testing so we can safe some threads here */
+	vdev_file_taskq = taskq_create("z_vdev_file", 1,
+	    minclsyspri, MIN(boot_ncpus, 4), INT_MAX, TASKQ_DYNAMIC);
 
 	VERIFY(vdev_file_taskq);
 }


### PR DESCRIPTION
This fix significantly reduces the number of threads in uzfs while maintaining the same performance as before. Performance was verified on a VM and bare metal as well. This affects all taskqs used in uzfs. 

Explanation of changes in general:
 * Upper bounds on number of threads preserved
 * Default and minimal number of threads tuned down
 * Instead of max_ncpus (hardcoded to 64) as the default and minimal number of threads, we use boot_ncpus (= available cpus). We still limit boot_ncpus to max_ncpus in case of systems with > 64 cpus.

Explanation of changes in zio taskqs:
 * in general numbers for read, write and free operations were reduced
 * radically reduced min and default number of interrupt threads for read and write. Those are called from aio poller thread sequentially. Write done callbacks are not even executed on behalf of a zio thread but directly by poller thread.

On a system with 1 cpu the default number of threads is around 10. Previously it was around 300. On a system with 100 cpus it is around 200.