### PR TITLE
added callback function in uzfs_get_txg_diff_tree

### DIFF
--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -30,7 +30,7 @@
 
 extern void populate_data(char *buf, uint64_t offset, int idx,
     uint64_t block_size);
-static int uzfs_test_txg_diff_traverse(off_t offset, size_t len,
+static int uzfs_test_txg_diff_traverse_cb(off_t offset, size_t len,
     uint64_t blkid, void *arg);
 static int del_from_txg_diff_tree(avl_tree_t *tree, uint64_t b_offset,
     uint64_t b_len);
@@ -150,7 +150,7 @@ uzfs_search_txg_diff_tree(avl_tree_t *tree, uint64_t offset, uint64_t *len)
 }
 
 static int
-uzfs_test_txg_diff_traverse(off_t offset, size_t len, uint64_t blkid, void *arg)
+uzfs_test_txg_diff_traverse_cb(off_t offset, size_t len, uint64_t blkid, void *arg)
 {
 	avl_tree_t *tree = (avl_tree_t *)arg;
 	add_to_txg_diff_tree(tree, offset, len);
@@ -228,8 +228,8 @@ uzfs_txg_diff_verifcation_test(void *arg)
 		txg_wait_synced(spa_get_dsl(spa), 0);
 		last_txg = spa_last_synced_txg(spa);
 
-		uzfs_get_txg_diff_tree(zvol, first_txg, last_txg,
-		    uzfs_test_txg_diff_traverse, (void *)modified_block_tree);
+		uzfs_get_txg_diff(zvol, first_txg, last_txg,
+		    uzfs_test_txg_diff_traverse_cb, (void *)modified_block_tree);
 
 		while ((blk_info = avl_destroy_nodes(write_io_tree,
 		    &cookie)) != NULL) {

--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -30,7 +30,7 @@
 
 extern void populate_data(char *buf, uint64_t offset, int idx,
     uint64_t block_size);
-static void uzfs_test_txg_diff_traverse(off_t offset, size_t len,
+static int uzfs_test_txg_diff_traverse(off_t offset, size_t len,
     uint64_t blkid, void *arg);
 static int del_from_txg_diff_tree(avl_tree_t *tree, uint64_t b_offset,
     uint64_t b_len);
@@ -149,11 +149,12 @@ uzfs_search_txg_diff_tree(avl_tree_t *tree, uint64_t offset, uint64_t *len)
 	return (1);
 }
 
-static void
+static int
 uzfs_test_txg_diff_traverse(off_t offset, size_t len, uint64_t blkid, void *arg)
 {
 	avl_tree_t *tree = (avl_tree_t *)arg;
 	add_to_txg_diff_tree(tree, offset, len);
+	return (0);
 }
 
 void

--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -150,7 +150,8 @@ uzfs_search_txg_diff_tree(avl_tree_t *tree, uint64_t offset, uint64_t *len)
 }
 
 static int
-uzfs_test_txg_diff_traverse_cb(off_t offset, size_t len, uint64_t blkid, void *arg)
+uzfs_test_txg_diff_traverse_cb(off_t offset, size_t len, uint64_t blkid,
+    void *arg)
 {
 	avl_tree_t *tree = (avl_tree_t *)arg;
 	add_to_txg_diff_tree(tree, offset, len);
@@ -229,7 +230,8 @@ uzfs_txg_diff_verifcation_test(void *arg)
 		last_txg = spa_last_synced_txg(spa);
 
 		uzfs_get_txg_diff(zvol, first_txg, last_txg,
-		    uzfs_test_txg_diff_traverse_cb, (void *)modified_block_tree);
+		    uzfs_test_txg_diff_traverse_cb,
+		    (void *)modified_block_tree);
 
 		while ((blk_info = avl_destroy_nodes(write_io_tree,
 		    &cookie)) != NULL) {

--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -28,11 +28,10 @@
 #include <uzfs_io.h>
 #include <uzfs_test.h>
 
-extern int total_time_in_sec;
 extern void populate_data(char *buf, uint64_t offset, int idx,
     uint64_t block_size);
-extern uint64_t block_size;
-
+static void uzfs_test_txg_diff_traverse(off_t offset, size_t len,
+    uint64_t blkid, void *arg);
 static int del_from_txg_diff_tree(avl_tree_t *tree, uint64_t b_offset,
     uint64_t b_len);
 static int uzfs_search_txg_diff_tree(avl_tree_t *tree, uint64_t offset,
@@ -150,6 +149,13 @@ uzfs_search_txg_diff_tree(avl_tree_t *tree, uint64_t offset, uint64_t *len)
 	return (1);
 }
 
+static void
+uzfs_test_txg_diff_traverse(off_t offset, size_t len, uint64_t blkid, void *arg)
+{
+	avl_tree_t *tree = (avl_tree_t *)arg;
+	add_to_txg_diff_tree(tree, offset, len);
+}
+
 void
 uzfs_txg_diff_verifcation_test(void *arg)
 {
@@ -175,6 +181,7 @@ uzfs_txg_diff_verifcation_test(void *arg)
 	buf = umem_alloc(block_size, UMEM_NOFAIL);
 
 	uzfs_create_txg_diff_tree((void **)&write_io_tree);
+	uzfs_create_txg_diff_tree((void **)&modified_block_tree);
 
 	now = gethrtime();
 	end = now + (hrtime_t)(total_time_in_sec * (hrtime_t)(NANOSEC));
@@ -221,7 +228,7 @@ uzfs_txg_diff_verifcation_test(void *arg)
 		last_txg = spa_last_synced_txg(spa);
 
 		uzfs_get_txg_diff_tree(zvol, first_txg, last_txg,
-		    (void **)&modified_block_tree);
+		    uzfs_test_txg_diff_traverse, (void *)modified_block_tree);
 
 		while ((blk_info = avl_destroy_nodes(write_io_tree,
 		    &cookie)) != NULL) {
@@ -233,13 +240,12 @@ uzfs_txg_diff_verifcation_test(void *arg)
 		VERIFY0(avl_numnodes(modified_block_tree));
 		VERIFY0(avl_numnodes(write_io_tree));
 		printf("%s : pass:%d\n", test_info->name, i);
-		umem_free(modified_block_tree, sizeof (*modified_block_tree));
-		modified_block_tree = NULL;
 	}
 
 	uzfs_close_dataset(zvol);
 	uzfs_close_pool(spa);
 	uzfs_destroy_txg_diff_tree(write_io_tree);
+	uzfs_destroy_txg_diff_tree(modified_block_tree);
 	umem_free(buf, block_size);
 }
 

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -108,7 +108,7 @@ typedef struct uzfs_zvol_blk_phy {
 	avl_node_t uzb_link;
 } uzfs_zvol_blk_phy_t;
 
-typedef int (uzfs_txg_diff_traverse_cb_t)(off_t offset, size_t len, uint64_t blkid,
-    void *arg);
+typedef int (uzfs_txg_diff_traverse_cb_t)(off_t offset, size_t len,
+    uint64_t blkid, void *arg);
 #endif
 #endif

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -108,7 +108,7 @@ typedef struct uzfs_zvol_blk_phy {
 	avl_node_t uzb_link;
 } uzfs_zvol_blk_phy_t;
 
-typedef int (uzfs_zvol_traverse_t)(off_t offset, size_t len, uint64_t blkid,
+typedef int (uzfs_txg_diff_traverse_cb_t)(off_t offset, size_t len, uint64_t blkid,
     void *arg);
 #endif
 #endif

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -108,5 +108,7 @@ typedef struct uzfs_zvol_blk_phy {
 	avl_node_t uzb_link;
 } uzfs_zvol_blk_phy_t;
 
+typedef int (uzfs_zvol_traverse_t)(off_t offset, size_t len, uint64_t blkid,
+    void *arg);
 #endif
 #endif

--- a/include/uzfs_mtree.h
+++ b/include/uzfs_mtree.h
@@ -23,11 +23,11 @@
 #define	_UZFS_MTREE_H
 
 /*
- * API to get modified blocks between start_txg and end_txg
- * Note: API will alocate condensed tree and populate it witch
- *	modified block details (offset:lenth entries).
+ * API to get modified block details between start_txg and end_txg
+ * Note: Caller needs to pass a callback function which will be called
+ *	for each modified block with (offset, length and blockId)
  */
-extern int uzfs_get_txg_diff_tree(void *zv, uint64_t start_txg,
+extern int uzfs_get_txg_diff(void *zv, uint64_t start_txg,
     uint64_t end_txg, void *func, void *arg);
 
 /*

--- a/include/uzfs_mtree.h
+++ b/include/uzfs_mtree.h
@@ -22,10 +22,30 @@
 #ifndef	_UZFS_MTREE_H
 #define	_UZFS_MTREE_H
 
+/*
+ * API to get modified blocks between start_txg and end_txg
+ * Note: API will alocate condensed tree and populate it witch
+ *	modified block details (offset:lenth entries).
+ */
 extern int uzfs_get_txg_diff_tree(void *zv, uint64_t start_txg,
-    uint64_t end_txg, void **tree);
+    uint64_t end_txg, void *func, void *arg);
+
+/*
+ * dump_txg_diff_tree will print all entries (offset:length) to stdout
+ */
 extern void dump_txg_diff_tree(void *tree);
+
+/*
+ * dump_io_incoming_tree will print all entries from incoming io tree
+ */
+extern void dump_io_incoming_tree(void *zv);
+
+/*
+ * uzfs_create_txg_diff_tree will create avl tree to store incoming io's
+ * during rebuilding
+ */
 extern void uzfs_create_txg_diff_tree(void **tree);
 extern void uzfs_destroy_txg_diff_tree(void *tree);
+
 extern int add_to_txg_diff_tree(void *tree, uint64_t offset, uint64_t size);
 #endif

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -34,6 +34,8 @@ extern int verify_err;
 extern int verify;
 extern int test_iterations;
 extern uint64_t active_size;
+extern uint64_t vol_size;
+extern uint64_t block_size;
 extern uint32_t create;
 extern char *pool;
 extern char *ds;

--- a/lib/libzpool/uzfs_mtree.c
+++ b/lib/libzpool/uzfs_mtree.c
@@ -30,7 +30,7 @@
 #define	TXG_DIFF_SNAPNAME	"tsnap"
 
 typedef struct uzfs_txg_diff_cb_args {
-	uzfs_zvol_traverse_t *func;
+	uzfs_txg_diff_traverse_cb_t *func;
 	uint64_t start_txg;
 	uint64_t end_txg;
 	void *arg_data;
@@ -212,8 +212,8 @@ uzfs_txg_diff_tree_compare(const void *arg1, const void *arg2)
 }
 
 int
-uzfs_get_txg_diff_tree(zvol_state_t *zv, uint64_t start_txg, uint64_t end_txg,
-    uzfs_zvol_traverse_t *func, void *arg)
+uzfs_get_txg_diff(zvol_state_t *zv, uint64_t start_txg, uint64_t end_txg,
+    uzfs_txg_diff_traverse_cb_t *func, void *arg)
 {
 	int error;
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];

--- a/lib/libzpool/uzfs_mtree.c
+++ b/lib/libzpool/uzfs_mtree.c
@@ -30,9 +30,10 @@
 #define	TXG_DIFF_SNAPNAME	"tsnap"
 
 typedef struct uzfs_txg_diff_cb_args {
-	avl_tree_t *uzfs_txg_diff_tree;
+	uzfs_zvol_traverse_t *func;
 	uint64_t start_txg;
 	uint64_t end_txg;
+	void *arg_data;
 } uzfs_txg_diff_cb_args_t;
 
 /*
@@ -197,9 +198,8 @@ uzfs_txg_diff_cb(spa_t *spa, zilog_t *zillog, const blkptr_t *bp,
 
 	blksz = BP_GET_LSIZE(bp);
 
-	add_to_txg_diff_tree(diff_blk_info->uzfs_txg_diff_tree,
-	    zb->zb_blkid * blksz, blksz);
-	return (0);
+	return diff_blk_info->func(zb->zb_blkid * blksz, blksz, zb->zb_blkid,
+	    diff_blk_info->arg_data);
 }
 
 static int
@@ -211,10 +211,9 @@ uzfs_txg_diff_tree_compare(const void *arg1, const void *arg2)
 	return (AVL_CMP(node1->offset, node2->offset));
 }
 
-
 int
 uzfs_get_txg_diff_tree(zvol_state_t *zv, uint64_t start_txg, uint64_t end_txg,
-    avl_tree_t **tree)
+    uzfs_zvol_traverse_t *func, void *arg)
 {
 	int error;
 	char snapname[ZFS_MAX_DATASET_NAME_LEN];
@@ -250,19 +249,13 @@ uzfs_get_txg_diff_tree(zvol_state_t *zv, uint64_t start_txg, uint64_t end_txg,
 
 	memset(&diff_blk, 0, sizeof (diff_blk));
 
-	diff_blk.uzfs_txg_diff_tree = umem_alloc(sizeof (avl_tree_t),
-	    UMEM_NOFAIL);
-	avl_create(diff_blk.uzfs_txg_diff_tree, uzfs_txg_diff_tree_compare,
-	    sizeof (uzfs_zvol_blk_phy_t),
-	    offsetof(uzfs_zvol_blk_phy_t, uzb_link));
-
+	diff_blk.func = func;
 	diff_blk.start_txg = start_txg;
 	diff_blk.end_txg = end_txg;
+	diff_blk.arg_data = arg;
 
 	error = traverse_dataset(ds_snap, start_txg,
 	    TRAVERSE_PRE, uzfs_txg_diff_cb, &diff_blk);
-
-	*tree = diff_blk.uzfs_txg_diff_tree;
 
 	dsl_dataset_long_rele(ds_snap, FTAG);
 	dsl_dataset_rele(ds_snap, FTAG);


### PR DESCRIPTION
Changes in uzfs_get_txg_diff_tree API
This API will traverse zvol and execute callback function provided by caller with offset/len/blockid.