### PR TITLE
assertion in debug mode when destroying zvol (#65)

### DIFF
--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -261,10 +261,13 @@ setup_unit_test(void)
 void
 unit_test_create_pool_ds(void)
 {
-	void *spa1, *spa2, *spa3, *spa4, *spa;
-	void *zv1 = NULL; void *zv3 = NULL;
-	void *zv2 = NULL; void *zv4 = NULL;
-	void *zv5 = NULL; void *zv = NULL;
+	spa_t *spa1, *spa2, *spa3, *spa4, *spa;
+	zvol_state_t *zv1 = NULL;
+	zvol_state_t *zv3 = NULL;
+	zvol_state_t *zv2 = NULL;
+	zvol_state_t *zv4 = NULL;
+	zvol_state_t *zv5 = NULL;
+	zvol_state_t *zv = NULL;
 	int err, err1, err2, err3, err4, err5;
 
 	err1 = uzfs_create_pool(pool, "/tmp/uztest.xyz", &spa1);
@@ -503,7 +506,7 @@ static void process_options(int argc, char **argv)
 }
 
 void
-open_pool(void **spa)
+open_pool(spa_t **spa)
 {
 	int err;
 	err = uzfs_open_pool(pool, spa);
@@ -514,7 +517,7 @@ open_pool(void **spa)
 }
 
 void
-open_ds(void *spa, void **zv)
+open_ds(spa_t *spa, zvol_state_t **zv)
 {
 	int err;
 	err = uzfs_open_dataset(spa, ds, zv);
@@ -527,7 +530,8 @@ open_ds(void *spa, void **zv)
 void
 unit_test_fn(void *arg)
 {
-	void *spa, *zv;
+	spa_t *spa;
+	zvol_state_t *zv;
 	kthread_t *reader1;
 	kthread_t *writer[3];
 	char name[MAXNAMELEN];

--- a/cmd/uzfs_test/uzfs_test_sync.c
+++ b/cmd/uzfs_test/uzfs_test_sync.c
@@ -140,7 +140,8 @@ done:
 void
 replay_fn(void *arg)
 {
-	void *spa, *zv;
+	spa_t *spa;
+	zvol_state_t *zv;
 	char name[MAXNAMELEN];
 	zvol_info_t *zinfo = NULL;
 

--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -167,7 +167,9 @@ uzfs_txg_diff_verifcation_test(void *arg)
 	hrtime_t end, now;
 	uint64_t blk_offset, offset, vol_blocks;
 	uint64_t io_num = 0;
-	void *spa, *zvol, *cookie = NULL;
+	spa_t *spa;
+	zvol_state_t *zvol;
+	void *cookie = NULL;
 	char *buf;
 	int max_io, count, i = 0;
 	avl_tree_t *write_io_tree;

--- a/cmd/uzfs_test/uzfs_zvol_zap.c
+++ b/cmd/uzfs_test/uzfs_zvol_zap.c
@@ -114,7 +114,8 @@ uzfs_zvol_zap_operation(void *arg)
 	uzfs_test_info_t *test_info = (uzfs_test_info_t *)arg;
 	int i = 0;
 	hrtime_t end, now;
-	void *spa, *zvol;
+	spa_t *spa;
+	zvol_state_t *zvol;
 	uzfs_zap_kv_t **kv_array;
 	int zap_count;
 	uint64_t txg1, txg2, txg3, txg4;

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -20,21 +20,23 @@
  */
 
 #ifndef	_UZFS_MGMT_H
-
 #define	_UZFS_MGMT_H
 
+#include <sys/spa.h>
+#include <sys/uzfs_zvol.h>
+
 extern int uzfs_init(void);
-extern int uzfs_create_pool(char *name, char *path, void **spa);
-extern int uzfs_open_pool(char *name, void **spa);
-extern int uzfs_vdev_add(void *spa, char *path, int ashift, int log);
-extern int uzfs_create_dataset(void *spa, char *ds, uint64_t vol_size,
-    uint64_t block_size, void **zv);
-extern int uzfs_open_dataset(void *spa, char *ds, void **zv);
+extern int uzfs_create_pool(char *name, char *path, spa_t **spa);
+extern int uzfs_open_pool(char *name, spa_t **spa);
+extern int uzfs_vdev_add(spa_t *spa, char *path, int ashift, int log);
+extern int uzfs_create_dataset(spa_t *spa, char *ds, uint64_t vol_size,
+    uint64_t block_size, zvol_state_t **zv);
+extern int uzfs_open_dataset(spa_t *spa, const char *ds, zvol_state_t **zv);
 extern int uzfs_zvol_create_cb(const char *ds_name, void *n);
 extern int uzfs_zvol_destroy_cb(const char *ds_name, void *n);
-extern uint64_t uzfs_synced_txg(void *zv);
-extern void uzfs_close_dataset(void *zv);
-extern void uzfs_close_pool(void *spa);
+extern uint64_t uzfs_synced_txg(zvol_state_t *zv);
+extern void uzfs_close_dataset(zvol_state_t *zv);
+extern void uzfs_close_pool(spa_t *spa);
 extern void uzfs_fini(void);
 extern uint64_t uzfs_random(uint64_t);
 

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -22,6 +22,8 @@
 #ifndef	_UZFS_TEST_H
 #define	_UZFS_TEST_H
 
+#include <sys/spa.h>
+#include <sys/uzfs_zvol.h>
 
 extern int silent;
 extern uint64_t io_block_size;
@@ -46,8 +48,8 @@ extern unsigned long zfs_arc_min;
 extern void replay_fn(void *arg);
 extern void setup_unit_test(void);
 extern void unit_test_create_pool_ds(void);
-extern void open_pool(void **);
-extern void open_ds(void *, void **);
+extern void open_pool(spa_t **);
+extern void open_ds(spa_t *, zvol_state_t **);
 
 typedef struct worker_args {
 	void *zv;

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -1,9 +1,10 @@
 #include <syslog.h>
 #include <sys/zil.h>
-#include <zrepl_mgmt.h>
 #include <sys/zfs_rlock.h>
 #include <sys/uzfs_zvol.h>
 #include <sys/dnode.h>
+#include <zrepl_mgmt.h>
+#include <uzfs_mgmt.h>
 
 #define	true 1
 #define	false 0
@@ -154,13 +155,7 @@ uzfs_zinfo_destroy(const char *name)
 		    zinfo->name[namelen] == '@'))) {
 			zv = zinfo->zv;
 			uzfs_remove_zinfo_list(zinfo);
-			zil_close(zv->zv_zilog);
-			zfs_rlock_destroy(&zv->zv_range_lock);
-			zfs_rlock_destroy(&zv->zv_mrange_lock);
-			dnode_rele(zv->zv_dn, zv);
-			dmu_objset_disown(zv->zv_objset, zv);
-			spa_close(zv->zv_spa, "UZINFO");
-			kmem_free(zv, sizeof (zvol_state_t));
+			uzfs_close_dataset(zv);
 			break;
 		}
 	}


### PR DESCRIPTION
The core of the change is about fixing references placed on spas from uzfs code. Each hold should have a unique tag because it is done on behalf of a different zvol (instead of a global tag). The other change is that the reference should not be bound to zinfo structure but rather to zvol_state structure, because that is the structure containing the actual spa reference. The code needs to be very clear in this regard.

Minor change bundled to this fix has been done to header and test files. It is not acceptable to define function in header files with different prototypes than real definitions in c files. And of course the c file which defines the functions needs to include the header file where the function is declared. That was quite messy and now that has been fixed.