### PR TITLE
Implement protocol version so that we can have mixed cluster during u…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,18 @@ env:
     - ZFS_BUILD_TAGS=0
     - ZFS_BUILD_TAGS=1
 before_install:
-    # sudo apt-get -qq update
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install --yes -qq gcc-6 g++-6
     - sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
     - sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
     - sudo apt-get install --yes -qq lcov libjemalloc-dev
     # packages for tests
     - sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
     - sudo apt-get install --yes -qq libgtest-dev cmake
+    # use gcc-6 by default
+    - sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+    - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
 install:
     - pushd .
     - cd /usr/src/gtest

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -16,4 +16,5 @@ test_uzfs_LDADD = \
 	$(top_builddir)/lib/libzfs/libzfs.la \
 	$(top_builddir)/lib/libzfs_core/libzfs_core.la
 
+test_uzfs_CXXFLAGS = -std=c++11
 test_uzfs_LDFLAGS = -pthread -lgtest -lgtest_main

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1,5 +1,16 @@
 
 #include <gtest/gtest.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+
+#include <zrepl_prot.h>
+
+/* Avoid including conflicting C++ declarations for LE-BE conversions */
+#define _SYS_BYTEORDER_H
 #include <libuzfs.h>
 
 TEST(uZFSServer, Setup) {
@@ -17,4 +28,220 @@ TEST(uZFSServer, InitServer) {
 
 TEST(uZFSServer, ClientConnectServer) {
 	EXPECT_EQ(0, libuzfs_client_init(NULL));
+}
+
+std::string getCmdPath(std::string zfsCmd) {
+	std::string cmdPath;
+	const char *srcPath = std::getenv("SRC_PATH");
+
+	if (srcPath == NULL) {
+		cmdPath += ".";
+	} else {
+		cmdPath = srcPath;
+	}
+	cmdPath += "/cmd/" + zfsCmd + "/" + zfsCmd;
+
+	return cmdPath;
+}
+
+void execCmd(std::string zfsCmd, std::string args) {
+	int rc;
+	std::string cmdLine;
+
+	cmdLine = getCmdPath(zfsCmd) + " " + args;
+	rc = system(cmdLine.c_str());
+	if (rc != 0) {
+		throw std::runtime_error(
+		    std::string("Command failed: ") + cmdLine);
+	}
+}
+
+class TestZvol {
+public:
+	TestZvol(std::string poolname) {
+		pool = poolname;
+		path = std::string("/tmp/") + pool;
+		name = pool + "/vol";
+	}
+
+	~TestZvol() {
+		try {
+			execCmd("zpool", std::string("destroy -f ") + pool);
+		} catch (std::runtime_error re) {
+			;
+		}
+		unlink(path.c_str());
+	}
+
+	void create() {
+		int fd, rc;
+
+		fd = open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
+		if (fd < 0)
+			throw std::system_error(errno, std::system_category(),
+			    "Cannot create vdev file");
+
+		rc = ftruncate(fd, 100 * 1024 * 1024);
+		close(fd);
+		if (rc != 0)
+			throw std::system_error(errno, std::system_category(),
+			    "Cannot truncate vdev file");
+		execCmd("zpool", std::string("create ") + pool + " " + path);
+		execCmd("zfs", std::string("create -V 10m -s ") + name);
+	}
+
+	std::string name;
+private:
+	std::string pool;
+	std::string path;
+};
+
+class ZreplTest : public testing::Test {
+protected:
+	ZreplTest() {
+		m_pid = 0;
+		m_fd = -1;
+		m_listenfd = -1;
+	}
+
+	~ZreplTest() {
+		if (m_listenfd >= 0)
+			close(m_listenfd);
+		if (m_fd >= 0)
+			close(m_fd);
+	}
+
+	virtual void SetUp () override {
+		std::string zrepl_path = getCmdPath("zrepl");
+
+		m_pid = fork();
+		if (m_pid == 0)
+			execl(zrepl_path.c_str(), zrepl_path.c_str(),
+			    "127.0.0.1", NULL);
+	}
+
+	virtual void TearDown() override {
+		if (m_pid != 0)
+			kill(m_pid, SIGTERM);
+	}
+
+	void connect(void) {
+		struct sockaddr_in addr;
+		int opt = 1;
+		int rc;
+
+		m_listenfd = socket(AF_INET, SOCK_STREAM, 0);
+		ASSERT_TRUE(m_listenfd >= 0);
+		setsockopt(m_listenfd, SOL_SOCKET, SO_REUSEADDR, (void *) &opt,
+		    sizeof (opt));
+		memset(&addr, 0, sizeof (addr));
+		addr.sin_family = AF_INET;
+		addr.sin_addr.s_addr = htonl(INADDR_ANY);
+		addr.sin_port = htons(TARGET_PORT);
+		rc = bind(m_listenfd, (struct sockaddr *) &addr, sizeof (addr));
+		ASSERT_TRUE(rc >= 0);
+		rc = listen(m_listenfd, 1);
+		ASSERT_TRUE(rc >= 0);
+		m_fd = accept(m_listenfd, NULL, NULL);
+		ASSERT_TRUE(m_fd >= 0);
+	}
+
+	pid_t	m_pid;
+	int	m_listenfd;
+	int	m_fd;
+};
+
+TEST_F(ZreplTest, HandshakeOk) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	mgmt_ack_t mgmt_ack;
+	TestZvol zvol("handshake");
+
+	connect();
+	sleep(5);
+	zvol.create();
+
+	hdr_out.version = REPLICA_VERSION;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = zvol.name.length() + 1;
+
+	rc = write(m_fd, &hdr_out, sizeof (hdr_out));
+	ASSERT_EQ(rc, sizeof (hdr_out));
+	rc = write(m_fd, zvol.name.c_str(), hdr_out.len);
+	ASSERT_EQ(rc, hdr_out.len);
+
+	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, sizeof (mgmt_ack));
+	rc = read(m_fd, &mgmt_ack, sizeof (mgmt_ack));
+	ASSERT_EQ(rc, sizeof (mgmt_ack));
+	EXPECT_STREQ(mgmt_ack.volname, zvol.name.c_str());
+}
+
+TEST_F(ZreplTest, HandshakeWrongVersion) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	mgmt_ack_t mgmt_ack;
+	TestZvol zvol("handshake");
+
+	connect();
+
+	hdr_out.version = REPLICA_VERSION + 1;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = zvol.name.length() + 1;
+
+	rc = write(m_fd, &hdr_out, sizeof (hdr_out));
+	ASSERT_EQ(rc, sizeof (hdr_out));
+	rc = write(m_fd, zvol.name.c_str(), hdr_out.len);
+	ASSERT_EQ(rc, hdr_out.len);
+
+	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_VERSION_MISMATCH);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, 0);
+}
+
+TEST_F(ZreplTest, HandshakeUnknownZvol) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	const char *volname = "handshake/vol";
+	mgmt_ack_t mgmt_ack;
+
+	connect();
+
+	hdr_out.version = REPLICA_VERSION;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = strlen(volname) + 1;
+
+	rc = write(m_fd, &hdr_out, sizeof (hdr_out));
+	ASSERT_EQ(rc, sizeof (hdr_out));
+	rc = write(m_fd, volname, hdr_out.len);
+	ASSERT_EQ(rc, hdr_out.len);
+
+	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, 0);
 }

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -593,6 +593,10 @@ filename=$SRCPOOL/vol2
 EOF
 
 	# run the fio
+	echo "Running $FIO_SRCDIR/fio with lib path $SRC_PATH/lib/fio/.libs"
+	echo " and following configuration:"
+	cat $TMPDIR/test.fio
+	echo
 	LD_LIBRARY_PATH=$SRC_PATH/lib/fio/.libs $FIO_SRCDIR/fio $TMPDIR/test.fio
 	[ $? -eq 0 ] || log_fail "Fio test run failed"
 


### PR DESCRIPTION
…pgrade (#55)

This is a proposal for versioning. Suggestions for improvements are welcomed. The most important change is new version field in zrepl messages which is at the first place in "packet". The field is taken into account only in handshake messages. Either client or server first reads initial two bytes which are the version number, and if it determines that the version is incompatible, it does not try to read the rest of the message. zrepl checks the version in handshake message from a target and replies with "version mismatch" error if the version is different from the one supported. In addition to that, it puts the supported version number into reply packet (again in the version field) and closes the connection. So in theory if target supports multiple protocol versions it can wait for a new connection from replica (happens every 5s) and send a handshake with supported version.

Other changes bundled with this change is removal of void pointer from network messages, fixed layout of structures used for network messages (not dependent on cpu architecture and compiler). Other than that I tried to keep the protocol as it was, with minimal changes.

Interesting are C++ unit tests which test three cases:
 * handshake with right version number
 * handshake with unsupported version number
 * handshake with unknown zvol name
