### PR TITLE
[cstor#44] Merge replication changes with latest code

### DIFF
--- a/cmd/uzfs_test/uzfs_rebuilding.c
+++ b/cmd/uzfs_test/uzfs_rebuilding.c
@@ -127,14 +127,12 @@ replica_reader_thread(void *arg)
 		if ((offset + len) > end)
 			len = end - offset;
 
-		err = uzfs_read_data(zvol1, buf1[idx], offset,
-		    len, NULL, NULL);
+		err = uzfs_read_data(zvol1, buf1[idx], offset, len, NULL);
 		if (err != 0)
 			printf("IO error at offset: %lu len: %lu\n", offset,
 			    len);
 
-		err = uzfs_read_data(zvol2, buf2[idx], offset,
-		    len, NULL, NULL);
+		err = uzfs_read_data(zvol2, buf2[idx], offset, len, NULL);
 		if (err != 0)
 			printf("IO error at offset: %lu len: %lu\n", offset,
 			    len);
@@ -182,8 +180,7 @@ uzfs_test_txg_diff_traverse_cb(off_t offset, size_t len,
 	io->len = len;
 	io->buf = umem_alloc(len, UMEM_NOFAIL);
 
-	err = uzfs_read_data(r_data->zvol, io->buf, offset, len,
-	    NULL, NULL);
+	err = uzfs_read_data(r_data->zvol, io->buf, offset, len, NULL);
 
 	if (err) {
 		umem_free(io, sizeof (*io));

--- a/cmd/uzfs_test/uzfs_txg_diff.c
+++ b/cmd/uzfs_test/uzfs_txg_diff.c
@@ -174,6 +174,7 @@ uzfs_txg_diff_verifcation_test(void *arg)
 	int max_io, count, i = 0;
 	avl_tree_t *write_io_tree;
 	avl_index_t where;
+	blk_metadata_t md;
 	uzfs_zvol_blk_phy_t *blk_info, temp_blk_info;
 
 	setup_unit_test();
@@ -214,8 +215,9 @@ uzfs_txg_diff_verifcation_test(void *arg)
 
 			populate_data(buf, offset, 0, block_size);
 
+			md.io_num = io_num;
 			if (uzfs_write_data(zvol, buf, offset, uzfs_random(1) ?
-			    block_size : io_block_size, &io_num, B_FALSE))
+			    block_size : io_block_size, &md, B_FALSE))
 				printf("IO error at offset: %lu len: %lu\n",
 				    offset, block_size);
 

--- a/include/uzfs_io.h
+++ b/include/uzfs_io.h
@@ -22,22 +22,34 @@
 #ifndef	_UZFS_IO_H
 #define	_UZFS_IO_H
 
+#include <sys/zil.h>
+
+struct metadata_desc;
+
+/*
+ * This describes a chunk of data associated with given meta data info.
+ */
+typedef struct metadata_desc {
+	struct metadata_desc *next; /* next entry in list ordered by offset */
+	size_t	len;	/* length of the chunk of data */
+	blk_metadata_t	metadata;
+} metadata_desc_t;
+
 /*
  * writes metadata 'md' to zil records
  * is_rebuild: if IO is from target then it should be set to FALSE
  *		else it should be set to TRUE (in case of rebuild IO)
  */
-extern int uzfs_write_data(void *zv, char *buf, uint64_t offset, uint64_t len,
-    void *md, boolean_t is_rebuild);
+int uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
+    blk_metadata_t *metadata, boolean_t is_rebuild);
 
 /*
- * calculates length required to store metadata for the data that it reads, and
- * reads metadata and assigns to 'md' and its length to 'mdlen'
+ * reads data and metadata. Meta data is a list which must be freed by caller.
  */
-extern int uzfs_read_data(void *zv, char *buf, uint64_t offset, uint64_t len,
-    void *md, uint64_t *mdlen);
+int uzfs_read_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
+    metadata_desc_t **md);
 
-extern void uzfs_flush_data(void *zv);
+extern void uzfs_flush_data(zvol_state_t *zv);
 
 /*
  * API to set/get rebuilding status
@@ -47,13 +59,14 @@ extern void uzfs_flush_data(void *zv);
  * flag set in uzfs_write_data, it will be checked with incoming_io_tree and
  * only non-overlapping part from IO will be written.
  */
-extern void uzfs_zvol_set_rebuild_status(void *zv, int status);
-extern int uzfs_zvol_get_rebuild_status(void *zv);
+extern void uzfs_zvol_set_rebuild_status(zvol_state_t *zv,
+    zvol_rebuild_status_t status);
+extern zvol_rebuild_status_t uzfs_zvol_get_rebuild_status(zvol_state_t *zv);
 
 /*
  * API to set/get zvol status
  */
-extern void uzfs_zvol_set_status(void *zv, int status);
-extern int uzfs_zvol_get_status(void *zv);
+extern void uzfs_zvol_set_status(zvol_state_t *zv, zvol_status_t status);
+extern zvol_status_t uzfs_zvol_get_status(zvol_state_t *zv);
 
 #endif

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -31,6 +31,8 @@ extern int uzfs_open_pool(char *name, spa_t **spa);
 extern int uzfs_vdev_add(spa_t *spa, char *path, int ashift, int log);
 extern int uzfs_create_dataset(spa_t *spa, char *ds, uint64_t vol_size,
     uint64_t block_size, zvol_state_t **zv);
+extern int uzfs_zvol_create_meta(objset_t *os, uint64_t block_size,
+    uint64_t meta_block_size, uint64_t meta_vol_block_size, dmu_tx_t *tx);
 extern int uzfs_open_dataset(spa_t *spa, const char *ds, zvol_state_t **zv);
 extern int uzfs_zvol_create_cb(const char *ds_name, void *n);
 extern int uzfs_zvol_destroy_cb(const char *ds_name, void *n);

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -27,6 +27,7 @@
 
 #include <pthread.h>
 #include <sys/queue.h>
+#include <uzfs_io.h>
 #include "zrepl_prot.h"
 
 #ifdef	__cplusplus
@@ -95,6 +96,7 @@ typedef struct zvol_io_cmd_s {
 	zvol_io_hdr_t 	hdr;
 	void		*zv;
 	void		*buf;
+	metadata_desc_t	*metadata_desc;
 	int		conn;
 } zvol_io_cmd_t;
 

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -22,6 +22,7 @@
 #include <sys/dmu_objset.h>
 #include <sys/uzfs_zvol.h>
 #include <uzfs_mtree.h>
+#include <uzfs_io.h>
 
 #define	GET_NEXT_CHUNK(chunk_io, offset, len, end)		\
 	do {							\
@@ -80,8 +81,7 @@ uzfs_write_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 	char *mdata = NULL, *tmdata = NULL, *tmdataend = NULL;
 
 	sync = (dmu_objset_syncprop(os) == ZFS_SYNC_ALWAYS) ? 1 : 0;
-	if (zv->zv_volmetablocksize == 0)
-		metadata = NULL;
+	ASSERT3P(zv->zv_volmetablocksize, !=, 0);
 
 	if (metadata != NULL) {
 		mlen = get_metadata_len(zv, offset, len);
@@ -189,9 +189,9 @@ exit_with_error:
 /* Reads data from volume 'zv', and fills up memory at buf */
 int
 uzfs_read_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
-    void **md, uint64_t *mdlen)
+    metadata_desc_t **md_head)
 {
-	int error = 0;
+	int error = EINVAL;	// in case we aren't able to read a single block
 	uint64_t blocksize = zv->zv_volblocksize;
 	uint64_t bytes = 0;
 	uint64_t volsize = zv->zv_volsize;
@@ -199,21 +199,19 @@ uzfs_read_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 	uint64_t read = 0;
 	objset_t *os = zv->zv_objset;
 	rl_t *rl, *mrl;
-	int ret = 0;
 	uint64_t r_offset;
-	void *mdata = NULL;
-	uint64_t mread = 0;
-	uint64_t mlen = 0;
 	metaobj_blk_offset_t metablk;
 	uint64_t len_in_first_aligned_block = 0;
+	metadata_desc_t *md_ent = NULL, *new_md;
+	blk_metadata_t *metadata;
+	int nmetas;
 
-	if (zv->zv_volmetablocksize == 0)
-		mdlen = NULL;
+	ASSERT3P(zv->zv_volmetadatasize, ==, sizeof (blk_metadata_t));
 
-	if (md != NULL && mdlen != NULL) {
-		mlen = get_metadata_len(zv, offset, len);
-		mdata = kmem_alloc(mlen, KM_SLEEP);
-		mread = 0;
+	/* init metadata in case caller wants to receive that info */
+	if (md_head != NULL) {
+		*md_head = NULL;
+		ASSERT3P(zv->zv_volmetablocksize, !=, 0);
 	}
 
 	r_offset = P2ALIGN_TYPED(offset, blocksize, uint64_t);
@@ -237,43 +235,78 @@ uzfs_read_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 			bytes = volsize - offset;
 
 		error = dmu_read(os, ZVOL_OBJ, offset, bytes, buf + read, 0);
-		if (error) {
-			ret = UZFS_IO_READ_FAIL;
-			goto exit_with_error;
-		}
+		if (error != 0)
+			goto exit;
 
-		if ((md != NULL) && (mdlen != NULL)) {
-			/* This assumes metavolblocksize same as volblocksize */
+		if (md_head != NULL) {
 			get_zv_metaobj_block_details(&metablk, zv, offset,
 			    bytes);
 
+			metadata = kmem_alloc(metablk.m_len, KM_SLEEP);
 			mrl = zfs_range_lock(&zv->zv_mrange_lock,
 			    metablk.m_offset, metablk.m_len, RL_READER);
 			error = dmu_read(os, ZVOL_META_OBJ, metablk.m_offset,
-			    metablk.m_len, mdata + mread, 0);
-			if (error) {
-				zfs_range_unlock(mrl);
-				ret = UZFS_IO_MREAD_FAIL;
-				goto exit_with_error;
-			}
+			    metablk.m_len, metadata, 0);
 			zfs_range_unlock(mrl);
-			mread += metablk.m_len;
+			if (error != 0) {
+				kmem_free(metadata, metablk.m_len);
+				goto exit;
+			}
+
+			nmetas = metablk.m_len / sizeof (*metadata);
+			ASSERT3P(zv->zv_metavolblocksize * nmetas, >=, bytes);
+			ASSERT3P(zv->zv_metavolblocksize * nmetas, <,
+			    bytes + blocksize);
+			for (int i = 0; i < nmetas; i++) {
+				new_md = NULL;
+				if (md_ent != NULL) {
+					/*
+					 * Join adjacent metadata with the same
+					 * io number into one descriptor.
+					 * Otherwise create a new one.
+					 */
+					if (md_ent->metadata.io_num ==
+					    metadata[i].io_num) {
+						md_ent->len +=
+						    zv->zv_metavolblocksize;
+					} else {
+						new_md = kmem_alloc(
+						    sizeof (metadata_desc_t),
+						    KM_SLEEP);
+						md_ent->next = new_md;
+					}
+				} else {
+					new_md = kmem_alloc(
+					    sizeof (metadata_desc_t),
+					    KM_SLEEP);
+					*md_head = new_md;
+				}
+				if (new_md != NULL) {
+					new_md->next = NULL;
+					new_md->len = zv->zv_metavolblocksize;
+					memcpy(&new_md->metadata, &metadata[i],
+					    sizeof (*metadata));
+					md_ent = new_md;
+				}
+			}
+			kmem_free(metadata, metablk.m_len);
 		}
 		offset += bytes;
 		read += bytes;
 		len -= bytes;
 	}
 
-exit_with_error:
+exit:
 	zfs_range_unlock(rl);
 
-	if (error == 0) {
-		VERIFY3P(mread, ==, mlen);
-	}
-
-	if ((md != NULL) && (mdlen != NULL)) {
-		*mdlen = mlen;
-		*md = mdata;
+	if (md_head != NULL && error != 0) {
+		md_ent = *md_head;
+		while (md_ent != NULL) {
+			new_md = md_ent->next;
+			kmem_free(md_ent, sizeof (metadata_desc_t));
+			md_ent = new_md;
+		}
+		*md_head = NULL;
 	}
 	return (error);
 }

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -219,53 +219,71 @@ ret:
 }
 
 /*
- * callback when a zvol objset is created
+ * Create zvol meta object and related entries in zvol zap object.
+ */
+int
+uzfs_zvol_create_meta(objset_t *os, uint64_t block_size,
+    uint64_t meta_block_size, uint64_t meta_vol_block_size, dmu_tx_t *tx)
+{
+	uint64_t metadatasize;
+	int error;
+
+	if (meta_block_size > block_size)
+		meta_block_size = block_size;
+	error = dmu_object_claim(os, ZVOL_META_OBJ, DMU_OT_ZVOL,
+	    meta_block_size, DMU_OT_NONE, 0, tx);
+	if (error != 0)
+		return (error);
+
+	metadatasize = sizeof (blk_metadata_t);
+	error = zap_update(os, ZVOL_ZAP_OBJ, "metadatasize", 8, 1,
+	    &metadatasize, tx);
+	if (error != 0)
+		return (error);
+
+	if (meta_vol_block_size > block_size)
+		meta_vol_block_size = block_size;
+	error = zap_update(os, ZVOL_ZAP_OBJ, "metavolblocksize", 8, 1,
+	    &meta_vol_block_size, tx);
+	if (error != 0)
+		return (error);
+
+	return (0);
+}
+
+/*
+ * callback when a zvol objset is created.
+ * Create the objects common to all uzfs datasets.
  * Any error here will bring down the process
+ *
+ * XXX this function duplicates the code from zvol_create_cb()
  */
 void
 uzfs_objset_create_cb(objset_t *new_os, void *arg, cred_t *cr, dmu_tx_t *tx)
 {
-	/*
-	 * Create the objects common to all uzfs datasets.
-	 */
-	uint64_t error, metablocksize, metadatasize, metavolblocksize;
-
-	zvol_properties_t *properties = (zvol_properties_t *)arg;
+	zvol_properties_t *props = (zvol_properties_t *)arg;
+	int error;
 
 	error = dmu_object_claim(new_os, ZVOL_OBJ, DMU_OT_ZVOL,
-	    properties->block_size, DMU_OT_NONE, 0, tx);
+	    props->block_size, DMU_OT_NONE, 0, tx);
 	VERIFY(error == 0);
 
 	error = zap_create_claim(new_os, ZVOL_ZAP_OBJ, DMU_OT_ZVOL_PROP,
 	    DMU_OT_NONE, 0, tx);
 	VERIFY(error == 0);
 
-	metablocksize = (properties->meta_block_size < properties->block_size) ?
-	    (properties->meta_block_size) : (properties->block_size);
-	error = dmu_object_claim(new_os, ZVOL_META_OBJ, DMU_OT_ZVOL,
-	    metablocksize, DMU_OT_NONE, 0, tx);
-	VERIFY(error == 0);
-
 	error = zap_update(new_os, ZVOL_ZAP_OBJ, "size", 8, 1,
-	    &properties->vol_size, tx);
+	    &props->vol_size, tx);
 	VERIFY(error == 0);
 
-	metadatasize = sizeof (blk_metadata_t);
-	error = zap_update(new_os, ZVOL_ZAP_OBJ, "metadatasize", 8, 1,
-	    &metadatasize, tx);
-	VERIFY(error == 0);
-
-	metavolblocksize = (properties->meta_vol_block_size <
-	    properties->block_size) ? (properties->meta_vol_block_size) :
-	    (properties->block_size);
-	error = zap_update(new_os, ZVOL_ZAP_OBJ, "metavolblocksize", 8, 1,
-	    &metavolblocksize, tx);
+	error = uzfs_zvol_create_meta(new_os, props->block_size,
+	    props->meta_block_size, props->meta_vol_block_size, tx);
 	VERIFY(error == 0);
 }
 
 
-/* owns objset with name 'ds_name' in pool 'spa'. Sets 'sync' property */
-int
+/* owns objset with name 'ds_name' in pool 'spa' */
+static int
 uzfs_open_dataset_init(const char *ds_name, zvol_state_t **z)
 {
 	zvol_state_t *zv = NULL;
@@ -278,8 +296,10 @@ uzfs_open_dataset_init(const char *ds_name, zvol_state_t **z)
 	spa_t *spa = NULL;
 
 	zv = kmem_zalloc(sizeof (zvol_state_t), KM_SLEEP);
-	if (zv == NULL)
+	if (zv == NULL) {
+		error = ENOMEM;
 		goto ret;
+	}
 
 	error = spa_open(ds_name, &spa, zv);
 	if (error != 0) {
@@ -309,23 +329,24 @@ uzfs_open_dataset_init(const char *ds_name, zvol_state_t **z)
 	if (error)
 		goto disown_free;
 
+	/* Meta-object may not exist if dataset wasn't created by uzfs */
 	error = dmu_object_info(os, ZVOL_META_OBJ, &doi);
+	if (error)
+		goto disown_free;
 
-	error |= zap_lookup(os, ZVOL_ZAP_OBJ, "metavolblocksize", 8, 1,
+	error = zap_lookup(os, ZVOL_ZAP_OBJ, "metavolblocksize", 8, 1,
 	    &meta_vol_block_size);
+	if (error)
+		goto disown_free;
 
-	error |= zap_lookup(os, ZVOL_ZAP_OBJ, "metadatasize", 8, 1,
+	error = zap_lookup(os, ZVOL_ZAP_OBJ, "metadatasize", 8, 1,
 	    &meta_data_size);
+	if (error)
+		goto disown_free;
 
-	if (error) {
-		zv->zv_volmetablocksize = 0;
-		zv->zv_volmetadatasize = 0;
-		zv->zv_metavolblocksize = 0;
-	} else {
-		zv->zv_volmetablocksize = doi.doi_data_block_size;
-		zv->zv_volmetadatasize = meta_data_size;
-		zv->zv_metavolblocksize = meta_vol_block_size;
-	}
+	zv->zv_volmetablocksize = doi.doi_data_block_size;
+	zv->zv_volmetadatasize = meta_data_size;
+	zv->zv_metavolblocksize = meta_vol_block_size;
 
 	error = dnode_hold(os, ZVOL_OBJ, zv, &zv->zv_dn);
 	if (error) {

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -93,6 +93,7 @@
 #include <sys/zvol.h>
 #else
 #include <libuzfs.h>
+#include <uzfs_mgmt.h>
 #include <sys/uzfs_zvol.h>
 #endif
 
@@ -319,6 +320,11 @@ zvol_create_cb(objset_t *os, void *arg, cred_t *cr, dmu_tx_t *tx)
 
 	error = zap_update(os, ZVOL_ZAP_OBJ, "size", 8, 1, &volsize, tx);
 	ASSERT(error == 0);
+
+#if !defined(_KERNEL)
+	VERIFY(uzfs_zvol_create_meta(os, volblocksize, volblocksize,
+	    volblocksize, tx) == 0);
+#endif
 }
 
 /*

--- a/tests/cbtest/gtest/.gitignore
+++ b/tests/cbtest/gtest/.gitignore
@@ -1,1 +1,2 @@
 /test_uzfs
+/test_zrepl_prot

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -4,10 +4,10 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-sbin_PROGRAMS = test_uzfs
+sbin_PROGRAMS = test_uzfs test_zrepl_prot
 
-test_uzfs_SOURCES = \
-	test_uzfs.cc
+test_uzfs_SOURCES = test_uzfs.cc
+test_zrepl_prot_SOURCES = test_zrepl_prot.cc
 
 test_uzfs_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
@@ -18,3 +18,4 @@ test_uzfs_LDADD = \
 
 test_uzfs_CXXFLAGS = -std=c++11
 test_uzfs_LDFLAGS = -pthread -lgtest -lgtest_main
+test_zrepl_prot_LDFLAGS = -pthread -lgtest -lgtest_main

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -1,13 +1,30 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018 CloudByte, Inc. All rights reserved.
+ */
 
 #include <gtest/gtest.h>
 #include <unistd.h>
-#include <signal.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <netinet/tcp.h>
-#include <netinet/in.h>
-
-#include <zrepl_prot.h>
 
 /* Avoid including conflicting C++ declarations for LE-BE conversions */
 #define _SYS_BYTEORDER_H
@@ -28,228 +45,4 @@ TEST(uZFSServer, InitServer) {
 
 TEST(uZFSServer, ClientConnectServer) {
 	EXPECT_EQ(0, libuzfs_client_init(NULL));
-}
-
-std::string getCmdPath(std::string zfsCmd) {
-	std::string cmdPath;
-	const char *srcPath = std::getenv("SRC_PATH");
-
-	if (srcPath == NULL) {
-		cmdPath += ".";
-	} else {
-		cmdPath = srcPath;
-	}
-	cmdPath += "/cmd/" + zfsCmd + "/" + zfsCmd;
-
-	return cmdPath;
-}
-
-void execCmd(std::string zfsCmd, std::string args) {
-	int rc;
-	std::string cmdLine;
-
-	cmdLine = getCmdPath(zfsCmd) + " " + args;
-	rc = system(cmdLine.c_str());
-	if (rc != 0) {
-		throw std::runtime_error(
-		    std::string("Command failed: ") + cmdLine);
-	}
-}
-
-class TestZvol {
-public:
-	TestZvol(std::string poolname) {
-		pool = poolname;
-		path = std::string("/tmp/") + pool;
-		name = pool + "/vol";
-	}
-
-	~TestZvol() {
-		try {
-			execCmd("zpool", std::string("destroy -f ") + pool);
-		} catch (std::runtime_error re) {
-			;
-		}
-		unlink(path.c_str());
-	}
-
-	void create() {
-		int fd, rc;
-
-		fd = open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
-		if (fd < 0)
-			throw std::system_error(errno, std::system_category(),
-			    "Cannot create vdev file");
-
-		rc = ftruncate(fd, 100 * 1024 * 1024);
-		close(fd);
-		if (rc != 0)
-			throw std::system_error(errno, std::system_category(),
-			    "Cannot truncate vdev file");
-		execCmd("zpool", std::string("create ") + pool + " " + path);
-		execCmd("zfs", std::string("create -V 10m -s ") + name);
-	}
-
-	std::string name;
-private:
-	std::string pool;
-	std::string path;
-};
-
-class ZreplTest : public testing::Test {
-protected:
-	ZreplTest() {
-		m_pid = 0;
-		m_fd = -1;
-		m_listenfd = -1;
-	}
-
-	~ZreplTest() {
-		if (m_listenfd >= 0)
-			close(m_listenfd);
-		if (m_fd >= 0)
-			close(m_fd);
-	}
-
-	virtual void SetUp () override {
-		std::string zrepl_path = getCmdPath("zrepl");
-
-		m_pid = fork();
-		if (m_pid == 0) {
-			execl(zrepl_path.c_str(), zrepl_path.c_str(),
-				"start", "-t", "127.0.0.1", NULL);
-		}
-
-	}
-
-	virtual void TearDown() override {
-		if (m_pid != 0)
-			kill(m_pid, SIGTERM);
-	}
-
-	void connect(void) {
-		struct sockaddr_in addr;
-		int opt = 1;
-		int rc;
-
-		m_listenfd = socket(AF_INET, SOCK_STREAM, 0);
-		ASSERT_TRUE(m_listenfd >= 0);
-		setsockopt(m_listenfd, SOL_SOCKET, SO_REUSEADDR, (void *) &opt,
-		    sizeof (opt));
-		memset(&addr, 0, sizeof (addr));
-		addr.sin_family = AF_INET;
-		addr.sin_addr.s_addr = htonl(INADDR_ANY);
-		addr.sin_port = htons(TARGET_PORT);
-		rc = bind(m_listenfd, (struct sockaddr *) &addr, sizeof (addr));
-		ASSERT_TRUE(rc >= 0);
-		rc = listen(m_listenfd, 1);
-		ASSERT_TRUE(rc >= 0);
-		m_fd = accept(m_listenfd, NULL, NULL);
-		ASSERT_TRUE(m_fd >= 0);
-	}
-
-	pid_t	m_pid;
-	int	m_listenfd;
-	int	m_fd;
-};
-
-TEST_F(ZreplTest, HandshakeOk) {
-	zvol_io_hdr_t hdr_out, hdr_in;
-	int rc;
-	mgmt_ack_t mgmt_ack;
-	TestZvol zvol("handshake");
-
-	connect();
-	zvol.create();
-
-	hdr_out.version = REPLICA_VERSION;
-	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
-	hdr_out.len = zvol.name.length() + 1;
-
-	rc = write(m_fd, &hdr_out, sizeof (hdr_out));
-	ASSERT_EQ(rc, sizeof (hdr_out));
-	rc = write(m_fd, zvol.name.c_str(), hdr_out.len);
-	ASSERT_EQ(rc, hdr_out.len);
-
-	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
-	ASSERT_EQ(rc, sizeof (hdr_in));
-	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
-	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
-	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
-	EXPECT_EQ(hdr_in.io_seq, 0);
-	EXPECT_EQ(hdr_in.offset, 0);
-	ASSERT_EQ(hdr_in.len, sizeof (mgmt_ack));
-	rc = read(m_fd, &mgmt_ack, sizeof (mgmt_ack));
-	ASSERT_EQ(rc, sizeof (mgmt_ack));
-	EXPECT_STREQ(mgmt_ack.volname, zvol.name.c_str());
-}
-
-TEST_F(ZreplTest, HandshakeWrongVersion) {
-	zvol_io_hdr_t hdr_out, hdr_in;
-	int rc;
-	char *msg;
-	mgmt_ack_t mgmt_ack;
-	TestZvol zvol("handshake");
-
-	connect();
-
-	hdr_out.version = REPLICA_VERSION + 1;
-	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
-	hdr_out.len = zvol.name.length() + 1;
-
-	/*
-	 * It must be set in one chunk so that server does not close the
-	 * connection after sending header but before sending zvol name.
-	 */
-	msg = (char *)malloc(sizeof (hdr_out) + hdr_out.len);
-	memcpy(msg, &hdr_out, sizeof (hdr_out));
-	memcpy(msg + sizeof (hdr_out), zvol.name.c_str(), hdr_out.len);
-	rc = write(m_fd, msg, sizeof (hdr_out) + hdr_out.len);
-	ASSERT_EQ(rc, sizeof (hdr_out) + hdr_out.len);
-	free(msg);
-
-	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
-	ASSERT_EQ(rc, sizeof (hdr_in));
-	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
-	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
-	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_VERSION_MISMATCH);
-	EXPECT_EQ(hdr_in.io_seq, 0);
-	EXPECT_EQ(hdr_in.offset, 0);
-	ASSERT_EQ(hdr_in.len, 0);
-}
-
-TEST_F(ZreplTest, HandshakeUnknownZvol) {
-	zvol_io_hdr_t hdr_out, hdr_in;
-	int rc;
-	const char *volname = "handshake/vol";
-	mgmt_ack_t mgmt_ack;
-
-	connect();
-
-	hdr_out.version = REPLICA_VERSION;
-	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
-	hdr_out.status = ZVOL_OP_STATUS_OK;
-	hdr_out.io_seq = 0;
-	hdr_out.offset = 0;
-	hdr_out.len = strlen(volname) + 1;
-
-	rc = write(m_fd, &hdr_out, sizeof (hdr_out));
-	ASSERT_EQ(rc, sizeof (hdr_out));
-	rc = write(m_fd, volname, hdr_out.len);
-	ASSERT_EQ(rc, hdr_out.len);
-
-	rc = read(m_fd, &hdr_in, sizeof (hdr_in));
-	ASSERT_EQ(rc, sizeof (hdr_in));
-	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
-	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
-	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
-	EXPECT_EQ(hdr_in.io_seq, 0);
-	EXPECT_EQ(hdr_in.offset, 0);
-	ASSERT_EQ(hdr_in.len, 0);
 }

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -1,0 +1,617 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+
+/*
+ * Copyright (c) 2018 CloudByte, Inc. All rights reserved.
+ */
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netinet/tcp.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+#include <zrepl_prot.h>
+
+/* Prints errno string if cond is not true */
+#define	ASSERT_ERRNO(fname, cond)	do { \
+	if (!(cond)) { \
+		perror(fname); \
+		ASSERT_EQ(errno, 0); \
+	} \
+} while(0)
+
+void init_buf(void *buf, int len, const char *pattern) {
+	int i;
+	char c;
+	int pat_len = strlen(pattern);
+
+	for (i = 0; i < len; i++) {
+		c = pattern[i % pat_len];
+		((char *)buf)[i] = c;
+	}
+}
+
+int verify_buf(void *buf, int len, const char *pattern) {
+	int i;
+	char c;
+	int pat_len = strlen(pattern);
+
+	for (i = 0; i < len; i++) {
+		c = pattern[i % pat_len];
+		if (c != ((char *)buf)[i])
+			return 1;
+	}
+
+	return 0;
+}
+
+std::string getCmdPath(std::string zfsCmd) {
+	std::string cmdPath;
+	const char *srcPath = std::getenv("SRC_PATH");
+
+	if (srcPath == NULL) {
+		cmdPath += ".";
+	} else {
+		cmdPath = srcPath;
+	}
+	cmdPath += "/cmd/" + zfsCmd + "/" + zfsCmd;
+
+	return cmdPath;
+}
+
+void execCmd(std::string zfsCmd, std::string args) {
+	int rc;
+	std::string cmdLine;
+
+	cmdLine = getCmdPath(zfsCmd) + " " + args;
+	rc = system(cmdLine.c_str());
+	if (rc != 0) {
+		throw std::runtime_error(
+		    std::string("Command failed: ") + cmdLine);
+	}
+}
+
+pid_t start_zrepl() {
+	std::string zrepl_path = getCmdPath("zrepl");
+	pid_t pid;
+	int i;
+
+	pid = fork();
+	if (pid == 0) {
+		execl(zrepl_path.c_str(), zrepl_path.c_str(),
+			"start", "-t", "127.0.0.1", NULL);
+	}
+	/* wait for zrepl to come up - is there a better way? */
+	while (i < 10) {
+		try {
+			execCmd("zpool", "list");
+			return pid;
+		} catch (std::runtime_error &) {
+			sleep(1);
+			i++;
+		}
+	}
+	throw std::runtime_error(
+	    std::string("Timed out waiting for zrepl to come up"));
+}
+
+/*
+ * Listen for incoming connection from replica and return new connection fd.
+ */
+int setup_control_connection() {
+	struct sockaddr_in addr;
+	int listenfd, fd;
+	int opt = 1;
+	int rc;
+
+	listenfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (listenfd < 0) {
+		perror("socket");
+		return (-1);
+	}
+	setsockopt(listenfd, SOL_SOCKET, SO_REUSEADDR, (void *) &opt,
+	    sizeof (opt));
+	memset(&addr, 0, sizeof (addr));
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	addr.sin_port = htons(TARGET_PORT);
+	rc = bind(listenfd, (struct sockaddr *) &addr, sizeof (addr));
+	if (rc != 0) {
+		perror("bind");
+		close(listenfd);
+		return (-1);
+	}
+	rc = listen(listenfd, 1);
+	if (rc != 0) {
+		perror("listen");
+		close(listenfd);
+		return (-1);
+	}
+	fd = accept(listenfd, NULL, NULL);
+	if (rc < 0) {
+		perror("accept");
+		close(listenfd);
+		return (-1);
+	}
+	close(listenfd);
+	return fd;
+}
+
+class TestZvol {
+public:
+	TestZvol(std::string poolname) {
+		pool = poolname;
+		path = std::string("/tmp/") + pool;
+		name = pool + "/vol";
+	}
+
+	~TestZvol() {
+		try {
+			execCmd("zpool", std::string("destroy -f ") + pool);
+		} catch (std::runtime_error re) {
+			;
+		}
+		unlink(path.c_str());
+	}
+
+	void create() {
+		int fd, rc;
+
+		fd = open(path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0666);
+		if (fd < 0)
+			throw std::system_error(errno, std::system_category(),
+			    "Cannot create vdev file");
+
+		rc = ftruncate(fd, 100 * 1024 * 1024);
+		close(fd);
+		if (rc != 0)
+			throw std::system_error(errno, std::system_category(),
+			    "Cannot truncate vdev file");
+		execCmd("zpool", std::string("create ") + pool + " " + path);
+		execCmd("zfs", std::string("create -sV 10m -o volblocksize=4k ")
+		    + name);
+	}
+
+	std::string name;
+private:
+	std::string pool;
+	std::string path;
+};
+
+class ZreplHandshakeTest : public testing::Test {
+protected:
+	/* Shared setup hook for all zrepl handshake tests - called just once */
+	static void SetUpTestCase() {
+		m_pid = start_zrepl();
+		m_zvol = new TestZvol("handshake");
+		m_zvol->create();
+	}
+
+	static void TearDownTestCase() {
+		delete m_zvol;
+		if (m_pid > 0)
+			kill(m_pid, SIGTERM);
+	}
+
+	ZreplHandshakeTest() {
+		m_control_fd = -1;
+	}
+
+	virtual void SetUp() override {
+		m_control_fd = setup_control_connection();
+		ASSERT_GE(m_control_fd, 0);
+	}
+
+	virtual void TearDown() override {
+		if (m_control_fd >= 0)
+			close(m_control_fd);
+	}
+
+	static pid_t	m_pid;
+	static TestZvol *m_zvol;
+
+	int	m_control_fd;
+};
+
+pid_t ZreplHandshakeTest::m_pid = 0;
+TestZvol *ZreplHandshakeTest::m_zvol = NULL;
+
+class ZreplDataTest : public testing::Test {
+protected:
+	/* Shared setup hook for all zrepl data tests - called just once */
+	static void SetUpTestCase() {
+		zvol_io_hdr_t hdr_out, hdr_in;
+		mgmt_ack_t mgmt_ack;
+		m_zvol = new TestZvol("handshake");
+		int rc;
+
+		m_pid = start_zrepl();
+		m_control_fd = setup_control_connection();
+		ASSERT_GE(m_control_fd, 0);
+
+		m_zvol->create();
+
+		hdr_out.version = REPLICA_VERSION;
+		hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+		hdr_out.status = ZVOL_OP_STATUS_OK;
+		hdr_out.io_seq = 0;
+		hdr_out.offset = 0;
+		hdr_out.len = m_zvol->name.length() + 1;
+
+		rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
+		ASSERT_EQ(rc, sizeof (hdr_out));
+		rc = write(m_control_fd, m_zvol->name.c_str(), hdr_out.len);
+		ASSERT_EQ(rc, hdr_out.len);
+
+		rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
+		ASSERT_EQ(rc, sizeof (hdr_in));
+		EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+		EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+		EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+		EXPECT_EQ(hdr_in.io_seq, 0);
+		ASSERT_EQ(hdr_in.len, sizeof (mgmt_ack));
+		rc = read(m_control_fd, &mgmt_ack, sizeof (mgmt_ack));
+		ASSERT_EQ(rc, sizeof (mgmt_ack));
+		EXPECT_STREQ(mgmt_ack.volname, m_zvol->name.c_str());
+		m_host = std::string(mgmt_ack.ip);
+		m_port = mgmt_ack.port;
+	}
+
+	static void TearDownTestCase() {
+		delete m_zvol;
+		if (m_control_fd >= 0)
+			close(m_control_fd);
+		if (m_pid > 0)
+			kill(m_pid, SIGTERM);
+	}
+
+	ZreplDataTest() {
+		m_data_fd = -1;
+		m_ioseq = 0;
+	}
+
+	/*
+	 * Create data connection and send handshake msg for the zvol.
+	 */
+	virtual void SetUp() override {
+		struct sockaddr_in addr;
+		zvol_io_hdr_t hdr_out;
+		int rc;
+
+		m_data_fd = socket(AF_INET, SOCK_STREAM, 0);
+		ASSERT_TRUE(m_data_fd >= 0);
+		memset(&addr, 0, sizeof (addr));
+		addr.sin_family = AF_INET;
+		addr.sin_port = htons(m_port);
+		rc = inet_pton(AF_INET, m_host.c_str(), &addr.sin_addr);
+		ASSERT_TRUE(rc > 0);
+		rc = connect(m_data_fd, (struct sockaddr *)&addr, sizeof (addr));
+		if (rc != 0) {
+			perror("connect");
+			ASSERT_EQ(errno, 0);
+		}
+
+		hdr_out.version = REPLICA_VERSION;
+		hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+		hdr_out.status = ZVOL_OP_STATUS_OK;
+		hdr_out.io_seq = 0;
+		hdr_out.offset = 0;
+		hdr_out.len = m_zvol->name.length() + 1;
+
+		rc = write(m_data_fd, &hdr_out, sizeof (hdr_out));
+		ASSERT_EQ(rc, sizeof (hdr_out));
+		rc = write(m_data_fd, m_zvol->name.c_str(), hdr_out.len);
+		ASSERT_EQ(rc, hdr_out.len);
+	}
+
+	virtual void TearDown() override {
+		int rc, val;
+
+		if (m_data_fd >= 0) {
+			/*
+			 * We have to wait for the other end to close the
+			 * connection, because the next test case could
+			 * initiate a new connection before this one is
+			 * fully closed and cause a handshake error.
+			 */
+			shutdown(m_data_fd, SHUT_WR);
+			rc = read(m_data_fd, &val, sizeof (val));
+			ASSERT_EQ(rc, 0);
+			close(m_data_fd);
+		}
+	}
+
+	/*
+	 * Send header for data write. Leave write of actual data to the caller.
+	 * len is real length - including metadata headers.
+	 */
+	void write_data_start(size_t offset, int len) {
+		zvol_io_hdr_t hdr_out;
+		int rc;
+
+		hdr_out.version = REPLICA_VERSION;
+		hdr_out.opcode = ZVOL_OPCODE_WRITE;
+		hdr_out.status = ZVOL_OP_STATUS_OK;
+		hdr_out.io_seq = ++m_ioseq;
+		hdr_out.offset = offset;
+		hdr_out.len = len;
+
+		rc = write(m_data_fd, &hdr_out, sizeof (hdr_out));
+		ASSERT_EQ(rc, sizeof (hdr_out));
+	}
+
+	void write_data(void *buf, size_t offset, int len, uint64_t io_num) {
+		struct zvol_io_rw_hdr write_hdr;
+		int rc;
+
+		write_data_start(offset, sizeof (write_hdr) + len);
+
+		write_hdr.len = len;
+		write_hdr.io_num = io_num;
+		rc = write(m_data_fd, &write_hdr, sizeof (write_hdr));
+		ASSERT_EQ(rc, sizeof (write_hdr));
+		rc = write(m_data_fd, buf, len);
+		ASSERT_EQ(rc, len);
+	}
+
+	/*
+	 * Send command to read data and read reply header. Reading payload is
+	 * left to the caller.
+	 */
+	void read_data_start(size_t offset, int len, zvol_io_hdr_t *hdr_inp)
+	{
+		zvol_io_hdr_t hdr_out;
+		int rc;
+
+		hdr_out.version = REPLICA_VERSION;
+		hdr_out.opcode = ZVOL_OPCODE_READ;
+		hdr_out.status = ZVOL_OP_STATUS_OK;
+		hdr_out.io_seq = ++m_ioseq;
+		hdr_out.offset = offset;
+		hdr_out.len = len;
+
+		rc = write(m_data_fd, &hdr_out, sizeof (hdr_out));
+		ASSERT_EQ(rc, sizeof (hdr_out));
+		rc = read(m_data_fd, hdr_inp, sizeof (*hdr_inp));
+		ASSERT_EQ(rc, sizeof (*hdr_inp));
+		ASSERT_EQ(hdr_inp->opcode, ZVOL_OPCODE_READ);
+		ASSERT_EQ(hdr_inp->status, ZVOL_OP_STATUS_OK);
+		ASSERT_EQ(hdr_inp->io_seq, m_ioseq);
+		ASSERT_EQ(hdr_inp->offset, offset);
+	}
+
+	static pid_t	m_pid;
+	static int	m_control_fd;
+	static uint16_t m_port;
+	static std::string m_host;
+	static TestZvol *m_zvol;
+
+	int	m_data_fd;
+	int	m_ioseq;
+};
+
+pid_t ZreplDataTest::m_pid = 0;
+int ZreplDataTest::m_control_fd = -1;
+uint16_t ZreplDataTest::m_port = 0;
+std::string ZreplDataTest::m_host = "";
+TestZvol *ZreplDataTest::m_zvol = NULL;
+
+TEST_F(ZreplHandshakeTest, HandshakeOk) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	mgmt_ack_t mgmt_ack;
+
+	hdr_out.version = REPLICA_VERSION;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = m_zvol->name.length() + 1;
+
+	rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
+	ASSERT_EQ(rc, sizeof (hdr_out));
+	rc = write(m_control_fd, m_zvol->name.c_str(), hdr_out.len);
+	ASSERT_EQ(rc, hdr_out.len);
+
+	rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, sizeof (mgmt_ack));
+	rc = read(m_control_fd, &mgmt_ack, sizeof (mgmt_ack));
+	ASSERT_EQ(rc, sizeof (mgmt_ack));
+	EXPECT_STREQ(mgmt_ack.volname, m_zvol->name.c_str());
+}
+
+TEST_F(ZreplHandshakeTest, HandshakeWrongVersion) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	char *msg;
+
+	hdr_out.version = REPLICA_VERSION + 1;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = m_zvol->name.length() + 1;
+
+	/*
+	 * It must be set in one chunk so that server does not close the
+	 * connection after sending header but before sending zvol name.
+	 */
+	msg = (char *)malloc(sizeof (hdr_out) + hdr_out.len);
+	memcpy(msg, &hdr_out, sizeof (hdr_out));
+	memcpy(msg + sizeof (hdr_out), m_zvol->name.c_str(), hdr_out.len);
+	rc = write(m_control_fd, msg, sizeof (hdr_out) + hdr_out.len);
+	ASSERT_EQ(rc, sizeof (hdr_out) + hdr_out.len);
+	free(msg);
+
+	rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_VERSION_MISMATCH);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, 0);
+}
+
+TEST_F(ZreplHandshakeTest, HandshakeUnknownZvol) {
+	zvol_io_hdr_t hdr_out, hdr_in;
+	int rc;
+	const char *volname = "handshake/unknown";
+
+	hdr_out.version = REPLICA_VERSION;
+	hdr_out.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr_out.status = ZVOL_OP_STATUS_OK;
+	hdr_out.io_seq = 0;
+	hdr_out.offset = 0;
+	hdr_out.len = strlen(volname) + 1;
+
+	rc = write(m_control_fd, &hdr_out, sizeof (hdr_out));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (hdr_out));
+	rc = write(m_control_fd, volname, hdr_out.len);
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, hdr_out.len);
+
+	rc = read(m_control_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.version, REPLICA_VERSION);
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_HANDSHAKE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_FAILED);
+	EXPECT_EQ(hdr_in.io_seq, 0);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, 0);
+}
+
+/*
+ * Write two blocks with the same io_num and third one with a different io_num
+ * and test that read returns two metadata chunks.
+ */
+TEST_F(ZreplDataTest, ReadBlocks) {
+	zvol_io_hdr_t hdr_in;
+	struct zvol_io_rw_hdr read_hdr;
+	int rc;
+	struct zvol_io_rw_hdr write_hdr;
+	char buf[4096];
+
+	/* write 1th data block */
+	init_buf(buf, sizeof (buf), "cStor-data");
+	write_data(buf, 0, sizeof (buf), 123);
+	rc = read(m_data_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	EXPECT_EQ(hdr_in.io_seq, m_ioseq);
+	EXPECT_EQ(hdr_in.offset, 0);
+	ASSERT_EQ(hdr_in.len, sizeof (buf) + sizeof (write_hdr));
+
+	/* write two chunks with different IO nums in one request */
+	write_data_start(sizeof (buf), 2 * (sizeof (write_hdr) + sizeof (buf)));
+
+	write_hdr.len = sizeof (buf);
+	write_hdr.io_num = 123;
+	rc = write(m_data_fd, &write_hdr, sizeof (write_hdr));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (write_hdr));
+	rc = write(m_data_fd, buf, sizeof (buf));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (buf));
+
+	write_hdr.len = sizeof (buf);
+	write_hdr.io_num = 124;
+	rc = write(m_data_fd, &write_hdr, sizeof (write_hdr));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (write_hdr));
+	rc = write(m_data_fd, buf, sizeof (buf));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (buf));
+
+	rc = read(m_data_fd, &hdr_in, sizeof (hdr_in));
+	ASSERT_ERRNO("write", rc >= 0);
+	ASSERT_EQ(rc, sizeof (hdr_in));
+	EXPECT_EQ(hdr_in.opcode, ZVOL_OPCODE_WRITE);
+	EXPECT_EQ(hdr_in.status, ZVOL_OP_STATUS_OK);
+	EXPECT_EQ(hdr_in.io_seq, m_ioseq);
+
+	/* read all blocks at once and check IO nums */
+	read_data_start(0, 3 * sizeof (buf), &hdr_in);
+	ASSERT_EQ(hdr_in.len, 2 * sizeof (read_hdr) + 3 * sizeof (buf));
+
+	rc = read(m_data_fd, &read_hdr, sizeof (read_hdr));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (read_hdr));
+	ASSERT_EQ(read_hdr.io_num, 123);
+	ASSERT_EQ(read_hdr.len, 2 * sizeof (buf));
+	rc = read(m_data_fd, buf, sizeof (buf));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (buf));
+	rc = verify_buf(buf, sizeof (buf), "cStor-data");
+	ASSERT_EQ(rc, 0);
+	rc = read(m_data_fd, buf, sizeof (buf));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (buf));
+	rc = verify_buf(buf, sizeof (buf), "cStor-data");
+	ASSERT_EQ(rc, 0);
+
+	rc = read(m_data_fd, &read_hdr, sizeof (read_hdr));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (read_hdr));
+	ASSERT_EQ(read_hdr.io_num, 124);
+	ASSERT_EQ(read_hdr.len, sizeof (buf));
+	rc = read(m_data_fd, buf, read_hdr.len);
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, read_hdr.len);
+	rc = verify_buf(buf, sizeof (buf), "cStor-data");
+	ASSERT_EQ(rc, 0);
+}
+
+TEST_F(ZreplDataTest, ReadBlockWithoutMeta) {
+	zvol_io_hdr_t hdr_in;
+	struct zvol_io_rw_hdr read_hdr;
+	int rc;
+	char buf[4096];
+
+	read_data_start(1024 * sizeof (buf), sizeof (buf), &hdr_in);
+	ASSERT_EQ(hdr_in.len, sizeof (read_hdr) + sizeof (buf));
+
+	rc = read(m_data_fd, &read_hdr, sizeof (read_hdr));
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, sizeof (read_hdr));
+	ASSERT_EQ(read_hdr.io_num, 0);
+	ASSERT_EQ(read_hdr.len, sizeof (buf));
+	rc = read(m_data_fd, buf, read_hdr.len);
+	ASSERT_ERRNO("read", rc >= 0);
+	ASSERT_EQ(rc, read_hdr.len);
+}

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -25,7 +25,8 @@ ZFS="$SRC_PATH/cmd/zfs/zfs"
 ZDB="$SRC_PATH/cmd/zdb/zdb"
 TGT="$SRC_PATH/cmd/zrepl/zrepl start -t 127.0.0.1"
 TGT_IP="127.0.0.1"
-GTEST="$SRC_PATH/tests/cbtest/gtest/test_uzfs"
+GTEST_UZFS="$SRC_PATH/tests/cbtest/gtest/test_uzfs"
+GTEST_ZREPL_PROT="$SRC_PATH/tests/cbtest/gtest/test_zrepl_prot"
 ZTEST="$SRC_PATH/cmd/ztest/ztest"
 UZFS_TEST="$SRC_PATH/cmd/uzfs_test/uzfs_test"
 UZFS_TEST_SYNC_SH="$SRC_PATH/cmd/uzfs_test/uzfs_test_sync.sh"
@@ -566,14 +567,15 @@ test_raidz_pool()
 
 test_fio()
 {
+	[ -z "$FIO_SRCDIR" ] && log_fail "FIO_SRCDIR must be defined"
 	init_test
 	sleep 10
 
 	log_must $ZPOOL create -f $SRCPOOL \
 	    -o cachefile="$TMPDIR/zpool_$SRCPOOL.cache" \
 	    "$TMPDIR/test_disk1.img"
-	log_must $ZFS create -sV $VOLSIZE $SRCPOOL/vol1
-	log_must $ZFS create -sV $VOLSIZE $SRCPOOL/vol2
+	log_must $ZFS create -sV $VOLSIZE -o volblocksize=4k $SRCPOOL/vol1
+	log_must $ZFS create -sV $VOLSIZE -o volblocksize=4k $SRCPOOL/vol2
 
 	cat >$TMPDIR/test.fio <<EOF
 [global]
@@ -846,16 +848,17 @@ run_pool_test()
 
 run_zrepl_test()
 {
-  log_must run_zrepl_uzfs_test log 4096 disabled
-  #log_must run_zrepl_uzfs_test log 4096 always
-  #log_must run_zrepl_uzfs_test log 4096 standard
+	log_must run_zrepl_uzfs_test log 4096 disabled
+	#log_must run_zrepl_uzfs_test log 4096 always
+	#log_must run_zrepl_uzfs_test log 4096 standard
 }
 
 run_zvol_test()
 {
 	log_must run_uzfs_test
 	log_must run_dmu_test
-	log_must $GTEST
+	log_must $GTEST_UZFS
+	log_must $GTEST_ZREPL_PROT
 	log_must $ZTEST
 }
 


### PR DESCRIPTION
Create zvol meta object and related properties in zvol zap object even when dataset is created using zfs command. So now it is created when using uzfs_create_dataset used in our tests and also in ioctl creating a zvol. Missing path which hasn't been tested is the import path. The code for this path will be added when refcount problem is solved (I have strange problems exporting/importing pools with zrepl as of now).