### PR TITLE
104# want zfs_autoimport_disable to work for pools opened in user space

### DIFF
--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -83,7 +83,7 @@ spa_config_load(void)
 	struct _buf *file;
 	uint64_t fsize;
 
-#ifdef _KERNEL
+#if defined(_KERNEL) || defined(_UZFS)
 	if (zfs_autoimport_disable)
 		return;
 #endif


### PR DESCRIPTION
Signed-off-by: Jeffry Molanus <jeffry.molanus@openebs.io>


