### PR TITLE
zrepl: add command line argument processing #105

### DIFF
--- a/module/zfs/spa_config.c
+++ b/module/zfs/spa_config.c
@@ -66,7 +66,7 @@ static uint64_t spa_config_generation = 1;
  * userland pools when doing testing.
  */
 char *spa_config_path = ZPOOL_CACHE;
-int zfs_autoimport_disable = 1;
+int zfs_autoimport_disable = 0;
 
 /*
  * Called when the module is first loaded, this routine loads the configuration
@@ -83,7 +83,7 @@ spa_config_load(void)
 	struct _buf *file;
 	uint64_t fsize;
 
-#ifdef _KERNEL
+#if defined(_KERNEL) || defined(_UZFS)
 	if (zfs_autoimport_disable)
 		return;
 #endif

--- a/tests/cbtest/gtest/test_uzfs.cc
+++ b/tests/cbtest/gtest/test_uzfs.cc
@@ -115,9 +115,11 @@ protected:
 		std::string zrepl_path = getCmdPath("zrepl");
 
 		m_pid = fork();
-		if (m_pid == 0)
+		if (m_pid == 0) {
 			execl(zrepl_path.c_str(), zrepl_path.c_str(),
-			    "127.0.0.1", NULL);
+				"start", "-t", "127.0.0.1", NULL);
+		}
+
 	}
 
 	virtual void TearDown() override {

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -23,7 +23,7 @@ fi
 ZPOOL="$SRC_PATH/cmd/zpool/zpool"
 ZFS="$SRC_PATH/cmd/zfs/zfs"
 ZDB="$SRC_PATH/cmd/zdb/zdb"
-TGT="$SRC_PATH/cmd/zrepl/zrepl"
+TGT="$SRC_PATH/cmd/zrepl/zrepl start -t 127.0.0.1"
 TGT_IP="127.0.0.1"
 GTEST="$SRC_PATH/tests/cbtest/gtest/test_uzfs"
 ZTEST="$SRC_PATH/cmd/ztest/ztest"


### PR DESCRIPTION
104# want zfs_autoimport_disable to work for pools opened in user space

Signed-off-by: Jeffry Molanus <jeffry.molanus@openebs.io>
```
zrepl command args ...
where 'command' is one of:

	 import <pool_name> [-t ip address)]
	 start [-t ip address)]
```

The import logic is what matter most. In previous incarnations of zrepl, it did not allow to actually import a specific pool, rather it would open all pools by default - including pools you perhaps did not want. 

Also, as ZFS by default, loads any pool config it finds in the default cache file a tuneable (in zrepl ZFS already had one) has been added to prevent it from loading all pools during startup and/or invoking a zpool list command (which would also trigger autoloading in some cases) When this ENV variable is non NULL -- this auto-import feature is disabled and an import has to be done explicitly by the zpool command or passing a pool to import during instantiation of zrepl. 

The logic of parsing the target address from a conf file, has been removed as well