### PR TITLE
Granularity at which metadata is maintained should be configurable

### DIFF
--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -297,7 +297,7 @@ writer_thread(void *arg)
 			printf("WIO error at offset: %lu len: %lu\n", offset,
 			    (idx + 1) * block_size);
 
-		if (uzfs_test_id == 6) {
+		if (uzfs_test_id == 8) {
 			memcpy(&data[offset], buf[idx], (idx + 1)*block_size);
 			for (i = 0; i < (idx+1); i++) {
 				iodata[blk_offset+i] = io_num;
@@ -583,7 +583,7 @@ static void process_options(int argc, char **argv)
 	if (active_size > vol_size)
 		vol_size = active_size << 1;
 
-	if (uzfs_test_id == 6) {
+	if (uzfs_test_id == 8) {
 		data = kmem_zalloc(vol_size, KM_SLEEP);
 		vol_blocks = (vol_size) / io_block_size;
 		iodata = kmem_zalloc(vol_blocks*sizeof (uint64_t), KM_SLEEP);
@@ -695,7 +695,7 @@ unit_test_fn(void *arg)
 		cv_wait(&cv, &mtx);
 	mutex_exit(&mtx);
 
-	if (uzfs_test_id == 6)
+	if (uzfs_test_id == 8)
 		verify_vol_data(zv, io_block_size, active_size);
 
 	if (silent == 0)

--- a/cmd/uzfs_test/uzfs_test_sync.sh
+++ b/cmd/uzfs_test/uzfs_test_sync.sh
@@ -1,107 +1,110 @@
 #!/bin/bash
 for i in {1..10}
 do
-	log_must setup_uzfs_test nolog 4096 standard
-	sudo $UZFS_TEST -S -w -T 1 > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test nolog 4096 standard
+	sudo $UZFS_TEST -c -S -w -T 1 | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
 for i in {1..10}
 do
-	log_must setup_uzfs_test log 4096 standard
-	sudo $UZFS_TEST -S -l -T 1 -w > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test log 4096 standard
+	sudo $UZFS_TEST -c -S -l -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
+	if [ $? != 0 ]; then
+		exit 1;
+	fi
+done
+: '
+for i in {1..10}
+do
+#	log_must setup_uzfs_test nolog 4096 always
+	sudo $UZFS_TEST -c -S -s -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
+	if [ $? != 0 ]; then
+		exit 1;
+	fi
+
+	sudo $UZFS_TEST -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
 for i in {1..10}
 do
-	log_must setup_uzfs_test nolog 4096 always
-	sudo $UZFS_TEST -S -s -T 1 -w > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test log 4096 always
+	sudo $UZFS_TEST -c -S -l -s -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
+	if [ $? != 0 ]; then
+		exit 1;
+	fi
+done
+'
+
+for i in {1..10}
+do
+#	log_must setup_uzfs_test nolog 65536 standard
+	sudo $UZFS_TEST -c -S -i 8192 -b 65536 -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
+	if [ $? != 0 ]; then
+		exit 1;
+	fi
+
+	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
 for i in {1..10}
 do
-	log_must setup_uzfs_test log 4096 always
-	sudo $UZFS_TEST -S -l -s -T 1 -w > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test log 65536 standard
+	sudo $UZFS_TEST -c -S -i 8192 -b 65536 -l -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
-
+: '
 for i in {1..10}
 do
-	log_must setup_uzfs_test nolog 65536 standard
-	sudo $UZFS_TEST -S -i 8192 -b 65536 -T 1 -w > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test nolog 65536 always
+	sudo $UZFS_TEST -c -S -s -i 8192 -b 65536 -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
-	if [ $? != 0 ]; then
-		exit 1;
-	fi
-done
-for i in {1..10}
-do
-	log_must setup_uzfs_test log 65536 standard
-	sudo $UZFS_TEST -S -i 8192 -b 65536 -l -T 1 -w > $PWD/$1/uzfs_sync_data
-	if [ $? != 0 ]; then
-		exit 1;
-	fi
-
-	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
 for i in {1..10}
 do
-	log_must setup_uzfs_test nolog 65536 always
-	sudo $UZFS_TEST -S -s -i 8192 -b 65536 -T 1 -w > $PWD/$1/uzfs_sync_data
+#	log_must setup_uzfs_test log 65536 always
+	sudo $UZFS_TEST -c -S -i 8192 -b 65536 -l -s -T 1 -w | grep uzfs_sync_data > $PWD/$1/uzfs_sync_data
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 
-	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
+	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $2}' $PWD/$1/uzfs_sync_data` -m `awk '{print $3}' $PWD/$1/uzfs_sync_data`
 	if [ $? != 0 ]; then
 		exit 1;
 	fi
 done
-for i in {1..10}
-do
-	log_must setup_uzfs_test log 65536 always
-	sudo $UZFS_TEST -S -i 8192 -b 65536 -l -s -T 1 -w > $PWD/$1/uzfs_sync_data
-	if [ $? != 0 ]; then
-		exit 1;
-	fi
-
-	sudo $UZFS_TEST -i 8192 -b 65536 -T 1 -V `awk '{print $1}' $PWD/$1/uzfs_sync_data` -m `awk '{print $2}' $PWD/$1/uzfs_sync_data`
-	if [ $? != 0 ]; then
-		exit 1;
-	fi
-done
-exit 0
+'

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -45,6 +45,7 @@ typedef struct metaobj_blk_offset {
 	uint64_t r_offset;
 	uint64_t r_len;
 	uint64_t m_offset;
+	uint64_t m_len;
 } metaobj_blk_offset_t;
 
 /*
@@ -119,7 +120,7 @@ extern void zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
  * at 'offset' of lun and length of meta vol block size
  */
 void get_metaobj_block_details(metaobj_blk_offset_t *m, zvol_state_t *zv,
-    uint64_t offset);
+    uint64_t offset, uint64_t len);
 
 /*
  * returns len of metadata for data at 'offset' of lun and length 'len'

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -119,8 +119,11 @@ extern void zvol_log_write(zvol_state_t *zv, dmu_tx_t *tx, uint64_t offset,
  * returns through 'm' (offset, len) of the block containing metadata of data
  * at 'offset' of lun and length of meta vol block size
  */
-void get_metaobj_block_details(metaobj_blk_offset_t *m, zvol_state_t *zv,
+void get_zv_metaobj_block_details(metaobj_blk_offset_t *m, zvol_state_t *zv,
     uint64_t offset, uint64_t len);
+
+void get_metaobj_block_details(metaobj_blk_offset_t *m, uint64_t blocksize,
+    uint64_t metablocksize, uint64_t metadatasize, uint64_t offset, uint64_t l);
 
 /*
  * returns len of metadata for data at 'offset' of lun and length 'len'

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -62,6 +62,7 @@ typedef struct worker_args {
 	uint64_t active_size;
 	int sfd;
 	int max_iops;
+	uint64_t io_num;
 } worker_args_t;
 
 typedef struct uzfs_test_info {

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -62,7 +62,6 @@ typedef struct worker_args {
 	uint64_t active_size;
 	int sfd;
 	int max_iops;
-	uint64_t io_num;
 } worker_args_t;
 
 typedef struct uzfs_test_info {

--- a/lib/libzpool/uzfs_io.c
+++ b/lib/libzpool/uzfs_io.c
@@ -138,7 +138,8 @@ chunk_io:
 
 		if (metadata != NULL) {
 			/* This assumes metavolblocksize same as volblocksize */
-			get_metaobj_block_details(&metablk, zv, offset, bytes);
+			get_zv_metaobj_block_details(&metablk, zv, offset,
+			    bytes);
 
 			dmu_tx_hold_write(tx, ZVOL_META_OBJ, metablk.m_offset,
 			    metablk.m_len);
@@ -243,7 +244,8 @@ uzfs_read_data(zvol_state_t *zv, char *buf, uint64_t offset, uint64_t len,
 
 		if ((md != NULL) && (mdlen != NULL)) {
 			/* This assumes metavolblocksize same as volblocksize */
-			get_metaobj_block_details(&metablk, zv, offset, bytes);
+			get_zv_metaobj_block_details(&metablk, zv, offset,
+			    bytes);
 
 			mrl = zfs_range_lock(&zv->zv_mrange_lock,
 			    metablk.m_offset, metablk.m_len, RL_READER);

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -394,7 +394,7 @@ uzfs_create_dataset(spa_t *spa, char *ds_name, uint64_t vol_size,
 	properties.vol_size = vol_size;
 	properties.block_size = block_size;
 	properties.meta_block_size = block_size;
-	properties.meta_vol_block_size = block_size;
+	properties.meta_vol_block_size = 512;
 
 	error = dmu_objset_create(name, DMU_OST_ZVOL, 0,
 	    uzfs_objset_create_cb, &properties);

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -687,7 +687,7 @@ zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
 #if !defined(_KERNEL)
 	if (lr->lr_version == VERSION_1) {
 		get_metaobj_block_details(&metablk, zv, offset, length);
-		metadatasize = sizeof (blk_metadata_t);
+		metadatasize = zv->zv_volmetadatasize;
 		tmdata = mdata = kmem_alloc(metablk.m_len, KM_SLEEP);
 		tmdataend = mdata + metablk.m_len;
 		while (tmdata < tmdataend) {

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -613,20 +613,21 @@ zvol_replay_truncate(zvol_state_t *zv, lr_truncate_t *lr, boolean_t byteswap)
  */
 void
 get_metaobj_block_details(metaobj_blk_offset_t *m, zvol_state_t *zv,
-    uint64_t offset)
+    uint64_t offset, uint64_t len)
 {
 	uint64_t blocksize = zv->zv_metavolblocksize;
 	uint64_t metablocksize = zv->zv_volmetablocksize;
 	uint64_t metadatasize = zv->zv_volmetadatasize;
-	uint64_t entries, n_th_entry, metablock;
+	uint64_t s_offset, e_offset;
 
-	entries = (metablocksize / metadatasize);
-	n_th_entry = (offset / blocksize);
-	metablock = (n_th_entry / entries);
+	s_offset = (offset / blocksize) * metadatasize;
+	e_offset = ((offset + len - 1) / blocksize) * metadatasize;
 
-	m->r_offset = metablock;
-	m->r_len = metablocksize;
-	m->m_offset = n_th_entry * metadatasize;
+	m->r_offset = P2ALIGN_TYPED(s_offset, metablocksize, uint64_t);
+	m->r_len = P2ALIGN_TYPED(e_offset, metablocksize, uint64_t) - m->r_offset +
+	    metablocksize;
+	m->m_offset = s_offset;
+	m->m_len = (e_offset - s_offset + metadatasize);
 }
 
 uint64_t
@@ -659,7 +660,8 @@ zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
 #if !defined(_KERNEL)
 	blk_metadata_t *metadata = NULL;
 	metaobj_blk_offset_t metablk;
-	uint64_t version;
+	uint64_t version, metadatasize;
+	char *mdata = NULL, *tmdata, *tmdataend;
 #endif
 	if (byteswap)
 		byteswap_uint64_array(lr, sizeof (*lr));
@@ -684,9 +686,16 @@ zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
 
 #if !defined(_KERNEL)
 	if (lr->lr_version == VERSION_1) {
-		get_metaobj_block_details(&metablk, zv, offset);
+		get_metaobj_block_details(&metablk, zv, offset, length);
+		metadatasize = sizeof (blk_metadata_t);
+		tmdata = mdata = kmem_alloc(metablk.m_len, KM_SLEEP);
+		tmdataend = mdata + metablk.m_len;
+		while (tmdata < tmdataend) {
+			memcpy(tmdata, metadata, metadatasize);
+			tmdata += metadatasize;
+		}
 		dmu_tx_hold_write(tx, ZVOL_META_OBJ, metablk.m_offset,
-		    sizeof (blk_metadata_t));
+		    metablk.m_len);
 	}
 #endif
 
@@ -697,10 +706,12 @@ zvol_replay_write(zvol_state_t *zv, lr_write_t *lr, boolean_t byteswap)
 		dmu_write(os, ZVOL_OBJ, offset, length, data, tx);
 #if !defined(_KERNEL)
 		if (lr->lr_version == VERSION_1) {
-			get_metaobj_block_details(&metablk, zv, offset);
+			get_metaobj_block_details(&metablk, zv, offset, length);
 			dmu_write(os, ZVOL_META_OBJ, metablk.m_offset,
-			    sizeof (blk_metadata_t), metadata, tx);
+			    metablk.m_len, mdata, tx);
 		}
+		if (mdata != NULL)
+			kmem_free(mdata, metablk.m_len);
 #endif
 		dmu_tx_commit(tx);
 	}

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -107,7 +107,6 @@ close_test()
 	if [ $TGT_PID -ne -1 ]; then
 		kill -SIGKILL $TGT_PID
 	fi
-
 	rm "$TMPDIR/test_disk1.img"
 	rm "$TMPDIR/test_disk2.img"
 	rm "$TMPDIR/test_disk3.img"
@@ -687,6 +686,16 @@ run_uzfs_test()
 {
 	log_must_not $UZFS_TEST
 
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -T 6
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -T 6
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -T 6
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -T 6
+
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -i 8192 -b 65536 -T 6
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -i 8192 -b 65536 -T 6
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 6
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -i 8192 -b 65536 -T 6
+
 	log_must truncate -s 2G "$TMPDIR/uztest.1a"
 	log_must truncate -s 2G "$TMPDIR/uztest.log"
 
@@ -701,7 +710,7 @@ run_uzfs_test()
 	log_must_not greater $ios1 $ios2
 
 	log_must setup_uzfs_test nolog 4096 standard
-	log_must $UZFS_TEST -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -T 2
+	log_must $UZFS_TEST -t 30 -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -T 2
 
 
 	log_must setup_uzfs_test log 4096 disabled
@@ -715,7 +724,7 @@ run_uzfs_test()
 	log_must_not greater $ios1 $ios2
 
 	log_must setup_uzfs_test log 4096 standard
-	log_must $UZFS_TEST -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -T 2
+	log_must $UZFS_TEST -t 30 -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -T 2
 
 
 	log_must setup_uzfs_test nolog 65536 disabled
@@ -729,7 +738,7 @@ run_uzfs_test()
 	log_must_not greater $ios1 $ios2
 
 	log_must setup_uzfs_test nolog 65536 standard
-	log_must $UZFS_TEST -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -i 8192 -b 65536 -T 2
+	log_must $UZFS_TEST -t 30 -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -i 8192 -b 65536 -T 2
 
 
 	log_must setup_uzfs_test log 65536 disabled
@@ -743,7 +752,8 @@ run_uzfs_test()
 	log_must_not greater $ios1 $ios2
 
 	log_must setup_uzfs_test log 65536 standard
-	log_must $UZFS_TEST -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 2
+	log_must $UZFS_TEST -t 30 -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 2
+
 
 
 	K=1024
@@ -757,7 +767,7 @@ run_uzfs_test()
 
 	log_must $UZFS_TEST -t 10 -T 0 -n 10
 
-#	log_must . $UZFS_TEST_SYNC_SH
+	log_must . $UZFS_TEST_SYNC_SH
 
 	log_must rm "$TMPDIR/uztest.1a"
 	log_must rm "$TMPDIR/uztest.log"

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -686,15 +686,15 @@ run_uzfs_test()
 {
 	log_must_not $UZFS_TEST
 
-	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -T 6
-	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -T 6
-	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -T 6
-	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -T 6
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -T 8
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -T 8
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -T 8
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -T 8
 
-	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -i 8192 -b 65536 -T 6
-	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -i 8192 -b 65536 -T 6
-	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 6
-	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -i 8192 -b 65536 -T 6
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -i 8192 -b 65536 -T 8
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -i 8192 -b 65536 -T 8
+	log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 8
+	#log_must $UZFS_TEST -t 30 -c -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -s -l -i 8192 -b 65536 -T 8
 
 	log_must truncate -s 2G "$TMPDIR/uztest.1a"
 	log_must truncate -s 2G "$TMPDIR/uztest.log"
@@ -754,7 +754,7 @@ run_uzfs_test()
 	log_must setup_uzfs_test log 65536 standard
 	log_must $UZFS_TEST -t 30 -v $UZFS_TEST_VOLSIZE_IN_NUM -a $UZFS_TEST_VOLSIZE_IN_NUM -l -i 8192 -b 65536 -T 2
 
-
+	log_must $UZFS_TEST -T 7
 
 	K=1024
 	M=$(( 1024 * 1024 ))


### PR DESCRIPTION
Current code maintains metadata at the 'volblocksize' granularity. IO path assumes that metadata is maintained at 'volblocksize' granularity.
This PR removes this assumption in IO path, sets metadata calculation at granularity of 512.
This PR doesn't cover the framework of setting this granularity.