### PR TITLE
Rebuilding related functionality added

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ env:
       ZFS_BUILD_TAGS=0
     - ZFS_TEST_TAGS=zrepl_test
       ZFS_BUILD_TAGS=0
+    - ZFS_TEST_TAGS=zrepl_rebuild_test
+      ZFS_BUILD_TAGS=0
     - ZFS_BUILD_TAGS=1
 before_install:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/cmd/uzfs_test/uzfs_test.c
+++ b/cmd/uzfs_test/uzfs_test.c
@@ -55,6 +55,7 @@ uzfs_test_info_t uzfs_tests[] = {
 	{ uzfs_test_get_metablk_details, "Tests offset,len calculations of"\
 	    " metadata for given data block" },
 	{ unit_test_fn, "zvol random read/write verification with metadata" },
+	{ zrepl_rebuild_test, "ZFS rebuild test" },
 };
 
 uint64_t metaverify = 0;

--- a/cmd/uzfs_test/zrepl_utest.c
+++ b/cmd/uzfs_test/zrepl_utest.c
@@ -15,6 +15,8 @@
 #include <zrepl_mgmt.h>
 
 char *tgt_port = "6060";
+char *ds1 = "ds1";
+static uint64_t last_io_seq_sent;
 
 struct data_io {
 	zvol_io_hdr_t hdr;
@@ -57,6 +59,7 @@ reader_thread(void *arg)
 	int *threads_done;
 	int write_ack_cnt = 0;
 	int read_ack_cnt = 0;
+	int sync_ack_cnt = 0;
 	zvol_io_hdr_t *hdr;
 	struct zvol_io_rw_hdr read_hdr;
 	worker_args_t *warg = (worker_args_t *)arg;
@@ -65,20 +68,25 @@ reader_thread(void *arg)
 	cv = warg->cv;
 	threads_done = warg->threads_done;
 
-	sfd = warg->sfd;
+	sfd = warg->sfd[0];
 	hdr = kmem_alloc(sizeof (zvol_io_hdr_t), KM_SLEEP);
 	buf = kmem_alloc(warg->io_block_size, KM_SLEEP);
-
 	printf("Start reading ........\n");
 	while (1) {
 		if ((warg->max_iops == write_ack_cnt) &&
-		    (warg->max_iops == read_ack_cnt)) {
+		    (warg->max_iops == read_ack_cnt) &&
+		    sync_ack_cnt) {
 			break;
 		}
 		count = read(sfd, (void *)hdr, sizeof (zvol_io_hdr_t));
 		if (count == -1) {
 			printf("Read error reader_thread\n");
 			break;
+		}
+
+		if (hdr->opcode == ZVOL_OPCODE_SYNC) {
+			sync_ack_cnt++;
+			continue;
 		}
 
 		if (hdr->opcode == ZVOL_OPCODE_WRITE) {
@@ -120,8 +128,9 @@ reader_thread(void *arg)
 		bzero(buf, warg->io_block_size);
 	}
 
-	printf("Total iops requested:%d writes:%d total reads: %d\n",
-	    warg->max_iops, write_ack_cnt, read_ack_cnt);
+	printf("Total iops requested:%d, total write acks%d,"
+	    " total read acks: %d total sync acks:%d\n",
+	    warg->max_iops, write_ack_cnt, read_ack_cnt, sync_ack_cnt);
 	free(hdr);
 	free(buf);
 	mutex_enter(mtx);
@@ -136,7 +145,7 @@ writer_thread(void *arg)
 {
 
 	int i = 0;
-	int sfd = -1;
+	int sfd, sfd1;
 	int count = 0;
 	int nbytes = 0;
 	kmutex_t *mtx;
@@ -145,13 +154,15 @@ writer_thread(void *arg)
 	struct data_io *io;
 	worker_args_t *warg = (worker_args_t *)arg;
 
-	sfd = warg->sfd;
+	sfd = warg->sfd[0];
+	sfd1 = warg->sfd[1];
 	mtx = warg->mtx;
 	cv = warg->cv;
 	threads_done = warg->threads_done;
 
 	io = kmem_alloc((sizeof (struct data_io) +
 	    warg->io_block_size), KM_SLEEP);
+	printf("Dataset generation start........... \n");
 
 	io->hdr.version = REPLICA_VERSION;
 	io->hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
@@ -170,6 +181,22 @@ writer_thread(void *arg)
 		goto exit;
 	}
 
+	if (warg->rebuild_test == B_TRUE) {
+		io->hdr.len    = strlen(ds1) + 1;
+		strncpy(io->buf, ds1, io->hdr.len);
+
+		count = write(sfd1, (void *)&(io->hdr), sizeof (zvol_io_hdr_t));
+		if (count == -1) {
+			printf("Sending HDR failed\n");
+			goto exit;
+		}
+
+		count = write(sfd1, (void *)(io->buf), io->hdr.len);
+		if (count == -1) {
+			printf("Sending volname is failed\n");
+			goto exit;
+		}
+	}
 	bzero(io, sizeof (struct data_io));
 	populate(io->buf, warg->io_block_size);
 
@@ -178,14 +205,14 @@ writer_thread(void *arg)
 	while (i < warg->max_iops) {
 		io->hdr.version = REPLICA_VERSION;
 		io->hdr.opcode = ZVOL_OPCODE_WRITE;
-		io->hdr.io_seq = i;
+		io->hdr.checkpointed_io_seq = io->hdr.io_seq = i + 1;
 		io->hdr.len = sizeof (struct zvol_io_rw_hdr) +
 		    warg->io_block_size;
 		io->hdr.status = 0;
 		io->hdr.flags = 0;
 		io->hdr.offset = nbytes;
 		io->rw_hdr.len = warg->io_block_size;
-		io->rw_hdr.io_num = i;
+		io->rw_hdr.io_num = i + 1;
 
 		int bytes = sizeof (struct data_io) + warg->io_block_size;
 		char *p = (char *)io;
@@ -198,10 +225,41 @@ writer_thread(void *arg)
 			bytes -= count;
 			p += count;
 		}
+
+		if ((warg->rebuild_test == B_TRUE) &&
+		    (i < (warg->max_iops / 2))) {
+			bytes = sizeof (struct data_io) + warg->io_block_size;
+			p = (char *)io;
+			while (bytes) {
+				count = write(sfd1, (void *)p, bytes);
+				if (count == -1) {
+					printf("Write error\n");
+					break;
+				}
+				bytes -= count;
+				p += count;
+			}
+		}
 		nbytes += warg->io_block_size;
 		i++;
+		last_io_seq_sent = io->hdr.checkpointed_io_seq;
 	}
 
+	io->hdr.version = REPLICA_VERSION;
+	io->hdr.opcode = ZVOL_OPCODE_SYNC;
+	count = write(sfd, (void *)&io->hdr, sizeof (io->hdr));
+	if (count == -1) {
+		printf("Error sending sync on ds0\n");
+		goto exit;
+	}
+
+	if (warg->rebuild_test == B_TRUE) {
+		count = write(sfd1, (void *)&io->hdr, sizeof (io->hdr));
+		if (count == -1) {
+			printf("Error sending sync on ds1\n");
+			goto exit;
+		}
+	}
 	/* Read and validate data */
 	i = 0;
 	nbytes = 0;
@@ -220,9 +278,20 @@ writer_thread(void *arg)
 			printf("Write error\n");
 			break;
 		}
+
+		if ((warg->rebuild_test == B_TRUE) &&
+		    (i < (warg->max_iops / 2))) {
+			count = write(sfd1, (void *)&io->hdr,
+			    sizeof (zvol_io_hdr_t));
+			if (count == -1) {
+				printf("Write error\n");
+				break;
+			}
+		}
 		nbytes += warg->io_block_size;
 		i++;
 	}
+	printf("Dataset generation completed.....\n");
 exit:
 	free(io);
 	mutex_enter(mtx);
@@ -267,6 +336,7 @@ zrepl_utest(void *arg)
 	writer_args.io_block_size = io_block_size;
 	writer_args.active_size = active_size;
 	writer_args.max_iops = max_iops;
+	writer_args.rebuild_test = B_FALSE;
 
 	reader_args.threads_done = &threads_done;
 	reader_args.mtx = &mtx;
@@ -274,6 +344,7 @@ zrepl_utest(void *arg)
 	reader_args.io_block_size = io_block_size;
 	reader_args.active_size = active_size;
 	reader_args.max_iops = max_iops;
+	reader_args.rebuild_test = B_FALSE;
 
 
 	sfd = create_and_bind(tgt_port, B_TRUE);
@@ -365,7 +436,7 @@ retry:
 	}
 	printf("Connect to replica IO port is successfully\n");
 
-	writer_args.sfd = reader_args.sfd = io_sfd;
+	writer_args.sfd[0] = reader_args.sfd[0] = io_sfd;
 	writer = zk_thread_create(NULL, 0,
 	    (thread_func_t)writer_thread, &writer_args, 0, NULL,
 	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
@@ -392,4 +463,308 @@ exit:
 	if (io_sfd != -1) {
 		close(io_sfd);
 	}
+}
+
+void
+zrepl_rebuild_test(void *arg)
+{
+	kmutex_t mtx;
+	kcondvar_t cv;
+	int count, sfd, rc;
+	int  io_sfd, io_sfd1, new_fd;
+	int threads_done = 0;
+	int num_threads = 0;
+	int wrong_message = 1;
+	kthread_t *reader[2];
+	kthread_t *writer;
+	socklen_t in_len;
+	zvol_io_hdr_t hdr;
+	mgmt_ack_t *mgmt_ack = NULL;
+	struct sockaddr in_addr;
+	zrepl_status_ack_t status_ack;
+	struct sockaddr_in replica_io_addr;
+	worker_args_t writer_args, reader_args[2];
+
+	io_block_size = 4096;
+	active_size = 0;
+	max_iops = 10000;
+	pool = "testp";
+	ds = "ds0";
+	ds1 = "ds1";
+
+	io_sfd = io_sfd1 = new_fd = sfd = -1;
+	mutex_init(&mtx, NULL, MUTEX_DEFAULT, NULL);
+	cv_init(&cv, NULL, CV_DEFAULT, NULL);
+
+	writer_args.threads_done = &threads_done;
+	writer_args.mtx = &mtx;
+	writer_args.cv = &cv;
+	writer_args.io_block_size = io_block_size;
+	writer_args.active_size = active_size;
+	writer_args.max_iops = max_iops;
+	writer_args.rebuild_test = B_TRUE;
+
+	reader_args[0].threads_done = &threads_done;
+	reader_args[0].mtx = &mtx;
+	reader_args[0].cv = &cv;
+	reader_args[0].io_block_size = io_block_size;
+	reader_args[0].active_size = active_size;
+	reader_args[0].max_iops = max_iops;
+	reader_args[0].rebuild_test = B_FALSE;
+
+	reader_args[1].threads_done = &threads_done;
+	reader_args[1].mtx = &mtx;
+	reader_args[1].cv = &cv;
+	reader_args[1].io_block_size = io_block_size;
+	reader_args[1].active_size = active_size;
+	reader_args[1].max_iops = max_iops/2;
+	reader_args[1].rebuild_test = B_TRUE;
+
+	sfd = create_and_bind(tgt_port, B_TRUE);
+	if (sfd == -1) {
+		return;
+	}
+
+	rc = listen(sfd, 10);
+	if (rc == -1) {
+		printf("listen() failed with errno:%d\n", rc);
+		goto exit;
+	}
+	printf("Listen was successful\n");
+
+start:
+	in_len = sizeof (in_addr);
+	new_fd = accept(sfd, &in_addr, &in_len);
+	if (new_fd == -1) {
+		printf("Unable to accept\n");
+		goto exit;
+	}
+	printf("Connection accepted from replica successful\n");
+
+	hdr.version = REPLICA_VERSION;
+	if (wrong_message) {
+		hdr.opcode = -1;
+		wrong_message = 0;
+	} else {
+		hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
+	}
+	hdr.len = strlen(ds)+1;
+	printf("Op code sent %d with len:%ld\n", hdr.opcode, hdr.len);
+
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("During hand shake Write error\n");
+		goto exit;
+	}
+	printf("header has been sent with count %d\n", count);
+
+	count = write(new_fd, ds, hdr.len);
+	if (count == -1) {
+		printf("During name send Write error\n");
+		goto exit;
+	}
+	printf("Volname has been sent with count %d\n", count);
+
+	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("During hdr Read error\n");
+		goto exit;
+	}
+	printf("Header has read with count %d\n", count);
+
+	if (hdr.status == ZVOL_OP_STATUS_FAILED) {
+		close(new_fd);
+		printf("Header status is failed\n");
+		goto start;
+	}
+
+	mgmt_ack = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
+
+	count = read(new_fd, (void *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("During mgmt Read error\n");
+		goto exit;
+	}
+
+	printf("Vol name: %s\n", mgmt_ack->volname);
+	printf("IP address: %s\n", mgmt_ack->ip);
+	printf("Port: %d\n", mgmt_ack->port);
+
+	bzero((char *)&replica_io_addr, sizeof (replica_io_addr));
+
+	replica_io_addr.sin_family = AF_INET;
+	replica_io_addr.sin_addr.s_addr = inet_addr(mgmt_ack->ip);
+	replica_io_addr.sin_port = htons(mgmt_ack->port);
+retry:
+	io_sfd = create_and_bind("", B_FALSE);
+	if (io_sfd == -1) {
+		printf("Socket creation failed with errno:%d\n", errno);
+		goto start;
+	}
+	rc = connect(io_sfd, (struct sockaddr *)&replica_io_addr,
+	    sizeof (replica_io_addr));
+	if (rc == -1) {
+		printf("Failed to connect to replica-IO port"
+		    " with errno:%d\n", errno);
+		close(io_sfd);
+		goto retry;
+	}
+	printf("Connect to replica IO port is successfully\n");
+
+	writer_args.sfd[0] = reader_args[0].sfd[0] = io_sfd;
+
+	io_sfd1 = create_and_bind("", B_FALSE);
+	if (io_sfd1 == -1) {
+		printf("Socket creation failed with errno:%d\n", errno);
+		goto start;
+	}
+	rc = connect(io_sfd1, (struct sockaddr *)&replica_io_addr,
+	    sizeof (replica_io_addr));
+	if (rc == -1) {
+		printf("Failed to connect to replica-IO port"
+		    " with errno:%d\n", errno);
+		close(io_sfd1);
+		goto retry;
+	}
+	printf("Connect to replica IO port is successfully\n");
+
+	writer_args.sfd[1] = reader_args[1].sfd[0] = io_sfd1;
+	writer = zk_thread_create(NULL, 0,
+	    (thread_func_t)writer_thread, &writer_args, 0, NULL,
+	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
+	num_threads++;
+	printf("Write_func thread created successfully\n");
+
+	reader[0] = zk_thread_create(NULL, 0, (thread_func_t)reader_thread,
+	    &reader_args[0], 0, NULL, TS_RUN, 0, PTHREAD_CREATE_DETACHED);
+	num_threads++;
+	printf("Reader_func thread-0 created successfully\n");
+
+	reader[1] = zk_thread_create(NULL, 0, (thread_func_t)reader_thread,
+	    &reader_args[1], 0, NULL, TS_RUN, 0, PTHREAD_CREATE_DETACHED);
+	num_threads++;
+	printf("Reader_func thread-1 created successfully\n");
+	mutex_enter(&mtx);
+	while (threads_done != num_threads)
+		cv_wait(&cv, &mtx);
+	mutex_exit(&mtx);
+	cv_destroy(&cv);
+	mutex_destroy(&mtx);
+	/* Start rebuilding operation */
+	/*
+	 * Step1: Send ZVOL_OPCODE_PREPARE_FOR_REBUILD message to
+	 * healthy replica and get rebuild_io port and ip from healthy
+	 * replica. ds0 is healthy replica in this case.
+	 */
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
+	hdr.len = strlen(ds)+1;
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
+	}
+
+	count = write(new_fd, ds, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending volname failed\n");
+		goto exit;
+	}
+
+
+	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in hdr read\n");
+		goto exit;
+	}
+
+	count = read(new_fd, (void *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
+		goto exit;
+	}
+
+	strncpy(mgmt_ack->dw_volname, ds1, sizeof (mgmt_ack->dw_volname));
+	printf("Healthy replica: %s\n", mgmt_ack->volname);
+	printf("Rebuilding IP address: %s\n", mgmt_ack->ip);
+	printf("Rebuilding Port: %d\n", mgmt_ack->port);
+	printf("Downgraded replica: %s\n", mgmt_ack->dw_volname);
+	/*
+	 * Step2: Send Rebuild IP address and Port to downgrade
+	 * replica. In this case ds1 is downgraded replica.
+	 */
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_START_REBUILD;
+	hdr.len = sizeof (mgmt_ack_t);
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Start_rebuild: sending hdr failed\n");
+		goto exit;
+	}
+
+	count = write(new_fd, (char *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("start_rebuild: sending volname failed\n");
+		goto exit;
+	}
+	printf("Rebuilding on volume:%s started ....\n", ds1);
+	/*
+	 * Step3: Check rebuild status of ds1.
+	 */
+status_check:
+	printf("Lets wait for healthy status of volume:%s\n", ds1);
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_REPLICA_STATUS;
+	hdr.len = strlen(ds1) + 1;
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Rebuild_status: sending hdr failed\n");
+		goto exit;
+	}
+
+	count = write(new_fd, ds1, hdr.len);
+	if (count == -1) {
+		printf("Rebuild_status: sending volname failed\n");
+		goto exit;
+	}
+
+	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Rebuild_status: error in hdr read\n");
+		goto exit;
+	}
+
+	if (hdr.status != ZVOL_OP_STATUS_OK) {
+		printf("Rebuild_status: response failed\n");
+		goto exit;
+	}
+
+	count = read(new_fd, (void *)&status_ack, hdr.len);
+	if (count == -1) {
+		printf("Rebuild_status: error in mgmt_ack read\n");
+		goto exit;
+	}
+
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		sleep(1);
+		goto status_check;
+	}
+exit:
+	printf("Replica is healthy now\n");
+	if (sfd != -1) {
+		close(sfd);
+	}
+
+	if (new_fd != -1) {
+		close(new_fd);
+	}
+
+	if (io_sfd != -1)
+		close(io_sfd);
+
+	if (io_sfd1 != -1)
+		close(io_sfd1);
+
+	if (mgmt_ack != NULL)
+		umem_free(mgmt_ack, sizeof (mgmt_ack_t));
 }

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -25,6 +25,7 @@
 #include <sys/zvol.h>
 #include <sys/zfs_rlock.h>
 #include <sys/zil.h>
+#include <zrepl_prot.h>
 
 #if !defined(_KERNEL)
 
@@ -47,7 +48,7 @@ typedef struct metaobj_blk_offset {
 	uint64_t m_offset;
 	uint64_t m_len;
 } metaobj_blk_offset_t;
-
+#if 0
 /*
  * zvol rebuild related state
  */
@@ -64,7 +65,7 @@ typedef enum zvol_status {
 	ZVOL_STATUS_HEALTHY,		/* zvol has latest data */
 	ZVOL_STATUS_DEGRADED		/* zvol is missing some data */
 } zvol_status_t;
-
+#endif
 /*
  * rebuild related information for zvol
  */
@@ -97,6 +98,7 @@ struct zvol_state {
 	zvol_rebuild_info_t rebuild_info;
 };
 
+#define	ZVOL_VOLUME_SIZE(zv)	(zv->zv_volsize)
 typedef struct zvol_state zvol_state_t;
 
 #define	UZFS_IO_TX_ASSIGN_FAIL	1

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -72,6 +72,7 @@ typedef enum zvol_status {
 typedef struct zvol_rebuild_info {
 	zvol_rebuild_status_t zv_rebuild_status; /* zvol rebuilding status */
 	uint64_t rebuild_bytes;
+	uint16_t rebuild_cnt;
 } zvol_rebuild_info_t;
 
 /*

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -48,24 +48,7 @@ typedef struct metaobj_blk_offset {
 	uint64_t m_offset;
 	uint64_t m_len;
 } metaobj_blk_offset_t;
-#if 0
-/*
- * zvol rebuild related state
- */
-typedef enum zvol_rebuild_status {
-	ZVOL_REBUILDING_INIT,		/* rebuilding initiated on zvol */
-	ZVOL_REBUILDING_IN_PROGRESS,	/* zvol is rebuilding */
-	ZVOL_REBUILDING_DONE		/* done with rebuilding */
-} zvol_rebuild_status_t;
 
-/*
- * zvol status
- */
-typedef enum zvol_status {
-	ZVOL_STATUS_HEALTHY,		/* zvol has latest data */
-	ZVOL_STATUS_DEGRADED		/* zvol is missing some data */
-} zvol_status_t;
-#endif
 /*
  * rebuild related information for zvol
  */

--- a/include/uzfs_test.h
+++ b/include/uzfs_test.h
@@ -60,8 +60,9 @@ typedef struct worker_args {
 	int *threads_done;
 	uint64_t io_block_size;
 	uint64_t active_size;
-	int sfd;
+	int sfd[2];
 	int max_iops;
+	int rebuild_test;
 } worker_args_t;
 
 typedef struct uzfs_test_info {
@@ -73,4 +74,5 @@ void uzfs_zvol_zap_operation(void *arg);
 void unit_test_fn(void *arg);
 void zrepl_utest(void *arg);
 void uzfs_rebuild_test(void *arg);
+void zrepl_rebuild_test(void *arg);
 #endif

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -46,12 +46,6 @@ typedef enum zvol_info_state_e {
 	ZVOL_INFO_STATE_OFFLINE,
 } zvol_info_state_t;
 
-typedef struct thread_args_s {
-	char zvol_name[MAXNAMELEN];
-	char dw_zvol_name[MAXNAMELEN];
-	int fd;
-} thread_args_t;
-
 typedef struct zvol_info_s {
 
 	SLIST_ENTRY(zvol_info_s) zinfo_next;
@@ -64,7 +58,6 @@ typedef struct zvol_info_s {
 	int		is_io_ack_sender_created;
 	uint64_t	checkpointed_io_seq;
 	taskq_t		*uzfs_zvol_taskq;	/* Taskq for minor management */
-	uint16_t 	rebuild_cnt;		/* Rebuild_cnt */
 
 	/* Thread sync related */
 
@@ -93,6 +86,12 @@ typedef struct zvol_info_s {
 	int 		read_req_ack_cnt;
 	int 		write_req_ack_cnt;
 } zvol_info_t;
+
+typedef struct thread_args_s {
+	char zvol_name[MAXNAMELEN];
+	zvol_info_t *zinfo;
+	int fd;
+} thread_args_t;
 
 typedef struct zvol_io_cmd_s {
 	STAILQ_ENTRY(zvol_io_cmd_s) cmd_link;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -48,6 +48,7 @@ typedef enum zvol_info_state_e {
 
 typedef struct thread_args_s {
 	char zvol_name[MAXNAMELEN];
+	char dw_zvol_name[MAXNAMELEN];
 	int fd;
 } thread_args_t;
 
@@ -63,6 +64,7 @@ typedef struct zvol_info_s {
 	int		is_io_ack_sender_created;
 	uint64_t	checkpointed_io_seq;
 	taskq_t		*uzfs_zvol_taskq;	/* Taskq for minor management */
+	uint16_t 	rebuild_cnt;		/* Rebuild_cnt */
 
 	/* Thread sync related */
 
@@ -100,6 +102,11 @@ typedef struct zvol_io_cmd_s {
 	metadata_desc_t	*metadata_desc;
 	int		conn;
 } zvol_io_cmd_t;
+
+typedef struct zvol_rebuild_s {
+	zvol_info_t	*zinfo;
+	int		fd;
+} zvol_rebuild_t;
 
 extern int uzfs_zinfo_init(void *zv, const char *ds_name);
 extern zvol_info_t *uzfs_zinfo_lookup(const char *name);

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -47,12 +47,21 @@ extern "C" {
 #define	MAX_IP_LEN	64
 #define	TARGET_PORT	6060
 
+#define	ZVOL_OP_FLAG_NORMAL 0x00
+#define	ZVOL_OP_FLAG_REBUILD 0x01
+
 enum zvol_op_code {
 	ZVOL_OPCODE_HANDSHAKE = 0,
 	ZVOL_OPCODE_READ,
 	ZVOL_OPCODE_WRITE,
-	ZVOL_OPCODE_UNMAP,
 	ZVOL_OPCODE_SYNC,
+	ZVOL_OPCODE_UNMAP,
+	ZVOL_OPCODE_REPLICA_STATUS,
+	ZVOL_OPCODE_PREPARE_FOR_REBUILD,
+	ZVOL_OPCODE_START_REBUILD,
+	ZVOL_OPCODE_REBUILD_STEP,
+	ZVOL_OPCODE_REBUILD_STEP_DONE,
+	ZVOL_OPCODE_REBUILD_COMPLETE,
 	ZVOL_OPCODE_SNAP_CREATE,
 	ZVOL_OPCODE_SNAP_ROLLBACK,
 } __attribute__((packed));
@@ -99,10 +108,37 @@ struct mgmt_ack {
 	uint16_t port;
 	char	ip[MAX_IP_LEN];
 	char	volname[MAX_NAME_LEN];
+	char	dw_volname[MAX_NAME_LEN];
 } __attribute__((packed));
 
 typedef struct mgmt_ack mgmt_ack_t;
 
+/*
+ * zvol rebuild related state
+ */
+enum zvol_rebuild_status {
+	ZVOL_REBUILDING_INIT,		/* rebuilding initiated on zvol */
+	ZVOL_REBUILDING_IN_PROGRESS,	/* zvol is rebuilding */
+	ZVOL_REBUILDING_DONE		/* done with rebuilding */
+} __attribute__((packed));
+
+typedef enum zvol_rebuild_status zvol_rebuild_status_t;
+/*
+ * zvol status
+ */
+enum zvol_status {
+	ZVOL_STATUS_HEALTHY,		/* zvol has latest data */
+	ZVOL_STATUS_DEGRADED		/* zvol is missing some data */
+} __attribute__((packed));
+
+typedef enum zvol_status zvol_status_t;
+
+struct zrepl_status_ack {
+	zvol_status_t state;
+	zvol_rebuild_status_t rebuild_status;
+} __attribute__((packed));
+
+typedef struct zrepl_status_ack zrepl_status_ack_t;
 /*
  * Describes chunk of data following this header.
  *

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -47,7 +47,6 @@ extern "C" {
 #define	MAX_IP_LEN	64
 #define	TARGET_PORT	6060
 
-#define	ZVOL_OP_FLAG_NORMAL 0x00
 #define	ZVOL_OP_FLAG_REBUILD 0x01
 
 enum zvol_op_code {
@@ -107,8 +106,8 @@ struct mgmt_ack {
 	uint64_t zvol_guid;
 	uint16_t port;
 	char	ip[MAX_IP_LEN];
-	char	volname[MAX_NAME_LEN];
-	char	dw_volname[MAX_NAME_LEN];
+	char	volname[MAX_NAME_LEN]; // Replica helping rebuild
+	char	dw_volname[MAX_NAME_LEN]; // Replica being rebuilt
 } __attribute__((packed));
 
 typedef struct mgmt_ack mgmt_ack_t;

--- a/lib/libzpool/uzfs_rebuilding.c
+++ b/lib/libzpool/uzfs_rebuilding.c
@@ -82,10 +82,10 @@ get_snapshot_zv(zvol_state_t *zv, char *snap_name, zvol_state_t **snap_zv)
 	if (ret == ENOENT) {
 		ret = dmu_objset_snapshot_one(zv->zv_name, snap_name);
 		if (ret) {
-			printf("Failed to create snapshot for %s\n",
-			    zv->zv_name);
+			printf("Failed to create snapshot for %s err(%d)\n",
+			    zv->zv_name, ret);
+			printf("vol:%s snap:%s\n", dataset, snap_name);
 			strfree(dataset);
-			strfree(snap_name);
 			return (ret);
 		}
 

--- a/tests/cbtest/gtest/test_zrepl_prot.cc
+++ b/tests/cbtest/gtest/test_zrepl_prot.cc
@@ -303,6 +303,7 @@ protected:
 		hdr_out.io_seq = ++m_ioseq;
 		hdr_out.offset = offset;
 		hdr_out.len = len;
+		hdr_out.flags = 0;
 
 		rc = write(m_data_fd, &hdr_out, sizeof (hdr_out));
 		ASSERT_EQ(rc, sizeof (hdr_out));


### PR DESCRIPTION
In cstor, we are writing user data in more than one volume for different reasons. Connection failure, power outage is normal and data may be out of sync on different volumes. We need to have a mechanism to re-sync data so that all volumes have latest(most updated) data. This mechanism is termed as rebuilding and this PR is meant for adding rebuilding functionality.

Unit testing: I have tested code by writing a program which helps to test rebuilding. What this program does is .....
1. It create two Volumes on replica.
2. Then it writes 10k IOs of size 4k in ds0 and 5k IOs of size 4k in ds1.
3. Then  it restart rebuilding activity by sharing IP+ Port details of replica ds0 with replica ds1
4. Now replica ds1 will open a rebuild connection with ds0 on this port and share checkpointed_io_seq 
    with replica ds0.
5. Replica ds0 try to find out IOs who has IO_seq greated than requested checkpointed_io_seq.
6. If such data exit then ds0 read it from disk and send it to replica ds1.
7. This activity keep going until full volume is canned.

It also take care of one to many rebuild in parallel.