### PR TITLE
[TA24]Rebuild failure handling functionality added

### DIFF
--- a/cmd/uzfs_test/zrepl_utest.c
+++ b/cmd/uzfs_test/zrepl_utest.c
@@ -65,33 +65,37 @@ zrepl_compare_data(char *buf1, char *buf2, int size)
 }
 
 int
-zrepl_utest_replica_handshake(char *volname, int fd,
-    mgmt_ack_t *mgmt_ack)
+zrepl_utest_mgmt_hs_io_conn(char *volname, int mgmt_fd)
 {
-	int count = 0;
-	zvol_io_hdr_t hdr;
+	int			rc = 0;
+	int			io_fd = 0;
+	mgmt_ack_t		*mgmt_ack;
+	zvol_io_hdr_t		hdr;
+	struct sockaddr_in	replica_io_addr;
+
 	bzero(&hdr, sizeof (hdr));
+	mgmt_ack = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
 
 	hdr.version = REPLICA_VERSION;
 	hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
 	hdr.len = strlen(volname) + 1;
 
-	count = write(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
+	rc = write(mgmt_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (rc == -1) {
 		printf("During handshake, Write error\n");
-		return (count);
+		return (rc);
 	}
 
-	count = write(fd, volname, hdr.len);
-	if (count == -1) {
+	rc = write(mgmt_fd, volname, hdr.len);
+	if (rc == -1) {
 		printf("During volname send, Write error\n");
-		return (count);
+		return (rc);
 	}
 
-	count = read(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
+	rc = read(mgmt_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (rc == -1) {
 		printf("During HDR read, Read error\n");
-		return (count);
+		return (rc);
 	}
 
 	if (hdr.status == ZVOL_OP_STATUS_FAILED) {
@@ -99,11 +103,98 @@ zrepl_utest_replica_handshake(char *volname, int fd,
 		return (-1);
 	}
 
-	count = read(fd, (void *)mgmt_ack, hdr.len);
-	if (count == -1) {
+	rc = read(mgmt_fd, (void *)mgmt_ack, hdr.len);
+	if (rc == -1) {
 		printf("During mgmt Read error\n");
-		return (count);
+		return (rc);
 	}
+
+	printf("Volume name:%s\n", mgmt_ack->volname);
+	printf("IP address:%s\n", mgmt_ack->ip);
+	printf("Port:%d\n", mgmt_ack->port);
+	printf("\n");
+
+	bzero((char *)&replica_io_addr, sizeof (replica_io_addr));
+
+	replica_io_addr.sin_family = AF_INET;
+	replica_io_addr.sin_addr.s_addr = inet_addr(mgmt_ack->ip);
+	replica_io_addr.sin_port = htons(mgmt_ack->port);
+
+	/* Data connection for ds0 */
+	io_fd = create_and_bind("", B_FALSE, B_FALSE);
+	if (io_fd == -1) {
+		printf("Socket creation failed with errno:%d\n", errno);
+		return (io_fd);
+	}
+
+	rc = connect(io_fd, (struct sockaddr *)&replica_io_addr,
+	    sizeof (replica_io_addr));
+	if (rc == -1) {
+		printf("Failed to connect to replica-IO port"
+		    " with errno:%d\n", errno);
+		close(io_fd);
+		return (-1);
+	}
+
+	rc = write(io_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (rc == -1) {
+		printf("During handshake, Write error\n");
+		return (rc);
+	}
+
+	rc = write(io_fd, volname, hdr.len);
+	if (rc == -1) {
+		printf("During volname send, Write error\n");
+		return (rc);
+	}
+	printf("Data-IO connection to volume:%s passed\n", volname);
+	return (io_fd);
+}
+
+int
+zrepl_utest_prepare_for_rebuild(char *healthy_vol, char *dw_vol,
+    int mgmt_fd, mgmt_ack_t *mgmt_ack)
+{
+
+	int		rc = 0;
+	zvol_io_hdr_t	hdr;
+
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
+	hdr.len = strlen(healthy_vol) + 1;
+
+	rc = write(mgmt_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (rc == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		return (rc);
+	}
+
+	rc = write(mgmt_fd, healthy_vol, hdr.len);
+	if (rc == -1) {
+		printf("Prepare_for_rebuild: sending volname failed\n");
+		return (rc);
+	}
+
+
+	rc = read(mgmt_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (rc == -1) {
+		printf("Prepare_for_rebuild: error in hdr read\n");
+		return (rc);
+	}
+
+	rc = read(mgmt_fd, (void *)mgmt_ack, hdr.len);
+	if (rc == -1) {
+		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
+		return (rc);
+	}
+
+	/* Copy dw_vol name in mgmt_ack */
+	strncpy(mgmt_ack->dw_volname, dw_vol,
+	    sizeof (mgmt_ack->dw_volname));
+	printf("Replica being rebuild is: %s\n", mgmt_ack->dw_volname);
+	printf("Replica helping rebuild is: %s\n", mgmt_ack->volname);
+	printf("Rebuilding IP address: %s\n", mgmt_ack->ip);
+	printf("Rebuilding Port: %d\n", mgmt_ack->port);
 	return (0);
 }
 
@@ -164,13 +255,13 @@ zrepl_utest_replica_rebuild_start(int fd, mgmt_ack_t *mgmt_ack,
 	hdr.len = size;
 	count = write(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
 	if (count == -1) {
-		printf("Start_rebuild: sending hdr failed\n");
+		printf("rebuild_start: sending hdr failed\n");
 		return (count);
 	}
 
 	count = write(fd, (char *)mgmt_ack, hdr.len);
 	if (count == -1) {
-		printf("start_rebuild: sending volname failed\n");
+		printf("rebuild_start: sending volname failed\n");
 		return (count);
 	}
 	return (0);
@@ -291,40 +382,6 @@ writer_thread(void *arg)
 	io = kmem_alloc((sizeof (struct data_io) +
 	    warg->io_block_size), KM_SLEEP);
 	printf("Dataset generation start........... \n");
-
-	io->hdr.version = REPLICA_VERSION;
-	io->hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
-	io->hdr.len    = strlen(ds) + 1;
-	strncpy(io->buf, ds, io->hdr.len);
-
-	count = write(sfd, (void *)&(io->hdr), sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Sending HDR failed\n");
-		goto exit;
-	}
-
-	count = write(sfd, (void *)(io->buf), io->hdr.len);
-	if (count == -1) {
-		printf("Sending volname is failed\n");
-		goto exit;
-	}
-
-	if (warg->rebuild_test == B_TRUE) {
-		io->hdr.len = strlen(ds1) + 1;
-		strncpy(io->buf, ds1, io->hdr.len);
-
-		count = write(sfd1, (void *)&(io->hdr), sizeof (zvol_io_hdr_t));
-		if (count == -1) {
-			printf("Sending HDR failed\n");
-			goto exit;
-		}
-
-		count = write(sfd1, (void *)(io->buf), io->hdr.len);
-		if (count == -1) {
-			printf("Sending volname is failed\n");
-			goto exit;
-		}
-	}
 	bzero(io, sizeof (struct data_io));
 	populate(io->buf, warg->io_block_size);
 
@@ -566,7 +623,7 @@ zrepl_utest(void *arg)
 {
 	kmutex_t mtx;
 	kcondvar_t cv;
-	int count, sfd, rc;
+	int sfd, rc;
 	int  io_sfd, new_fd;
 	int threads_done = 0;
 	int num_threads = 0;
@@ -576,7 +633,6 @@ zrepl_utest(void *arg)
 	mgmt_ack_t mgmt_ack;
 	zrepl_status_ack_t status_ack;
 	struct sockaddr in_addr;
-	struct sockaddr_in replica_io_addr;
 	worker_args_t writer_args, reader_args;
 
 	io_block_size = 4096;
@@ -618,7 +674,6 @@ zrepl_utest(void *arg)
 	}
 	printf("Listen was successful\n");
 
-start:
 	in_len = sizeof (in_addr);
 	new_fd = accept(sfd, &in_addr, &in_len);
 	if (new_fd == -1) {
@@ -627,36 +682,11 @@ start:
 	}
 
 	printf("Connection accepted from replica successfully\n");
-	count = zrepl_utest_replica_handshake(ds, new_fd, &mgmt_ack);
-	if (count == -1) {
+	io_sfd = zrepl_utest_mgmt_hs_io_conn(ds, new_fd);
+	if (io_sfd == -1) {
 		goto exit;
 	}
 
-	printf("Vol name: %s\n", mgmt_ack.volname);
-	printf("IP address: %s\n", mgmt_ack.ip);
-	printf("Port: %d\n", mgmt_ack.port);
-
-	bzero((char *)&replica_io_addr, sizeof (replica_io_addr));
-
-	replica_io_addr.sin_family = AF_INET;
-	replica_io_addr.sin_addr.s_addr = inet_addr(mgmt_ack.ip);
-	replica_io_addr.sin_port = htons(mgmt_ack.port);
-retry:
-	io_sfd = create_and_bind("", B_FALSE, B_FALSE);
-	if (io_sfd == -1) {
-		printf("Socket creation failed with errno:%d\n", errno);
-		goto start;
-	}
-	rc = connect(io_sfd, (struct sockaddr *)&replica_io_addr,
-	    sizeof (replica_io_addr));
-	if (rc == -1) {
-		printf("Failed to connect to replica-IO port"
-		    " with errno:%d\n", errno);
-		close(io_sfd);
-		sleep(1);
-		goto retry;
-	}
-	printf("Connect to replica IO port is successfully\n");
 
 	writer_args.sfd[0] = reader_args.sfd[0] = io_sfd;
 	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
@@ -748,20 +778,21 @@ zrepl_rebuild_test(void *arg)
 {
 	kmutex_t mtx;
 	kcondvar_t cv;
-	int i, count, sfd, rc;
-	int  io_sfd, io_sfd1, new_fd;
+	int i, count, sfd, rc, mgmt_fd;
+	int  ds0_io_sfd, ds1_io_sfd;
+	int  ds2_io_sfd, ds3_io_sfd;
 	int threads_done = 0;
 	int num_threads = 0;
 	kthread_t *reader[2];
 	kthread_t *writer;
 	socklen_t in_len;
-	zvol_io_hdr_t hdr;
+	mgmt_ack_t *p = NULL;
 	mgmt_ack_t *mgmt_ack = NULL;
+	mgmt_ack_t *mgmt_ack_ds1 = NULL;
 	mgmt_ack_t *mgmt_ack_ds2 = NULL;
 	mgmt_ack_t *mgmt_ack_ds3 = NULL;
 	struct sockaddr in_addr;
 	zrepl_status_ack_t status_ack;
-	struct sockaddr_in replica_io_addr;
 	worker_args_t writer_args, reader_args[2];
 
 	io_block_size = 4096;
@@ -771,7 +802,8 @@ zrepl_rebuild_test(void *arg)
 	ds = "ds0";
 	ds1 = "ds1";
 
-	io_sfd = io_sfd1 = new_fd = sfd = -1;
+	ds0_io_sfd = ds1_io_sfd = mgmt_fd = sfd = -1;
+	ds2_io_sfd = ds3_io_sfd = -1;
 	mutex_init(&mtx, NULL, MUTEX_DEFAULT, NULL);
 	cv_init(&cv, NULL, CV_DEFAULT, NULL);
 
@@ -811,70 +843,44 @@ zrepl_rebuild_test(void *arg)
 	}
 	printf("Listen was successful\n");
 
-start:
+
 	in_len = sizeof (in_addr);
-	new_fd = accept(sfd, &in_addr, &in_len);
-	if (new_fd == -1) {
+	mgmt_fd = accept(sfd, &in_addr, &in_len);
+	if (mgmt_fd == -1) {
 		printf("Unable to accept\n");
 		goto exit;
 	}
 	printf("Connection accepted from replica successfully\n");
 
-	/* Handshake for replica ds0 */
-	mgmt_ack = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
-	count = zrepl_utest_replica_handshake(ds, new_fd, mgmt_ack);
-	if (count == -1) {
+	/* Mgmt Handshake and IO-conn for replica ds0 */
+	ds0_io_sfd = zrepl_utest_mgmt_hs_io_conn(ds, mgmt_fd);
+	if (ds0_io_sfd == -1) {
 		goto exit;
 	}
 
-	printf("Vol name: %s\n", mgmt_ack->volname);
-	printf("IP address: %s\n", mgmt_ack->ip);
-	printf("Port: %d\n", mgmt_ack->port);
+	writer_args.sfd[0] = reader_args[0].sfd[0] = ds0_io_sfd;
 
-	bzero((char *)&replica_io_addr, sizeof (replica_io_addr));
+	/* Mgmt Handshake and IO-conn for replica ds1 */
+	ds1_io_sfd = zrepl_utest_mgmt_hs_io_conn(ds1, mgmt_fd);
+	if (ds1_io_sfd == -1) {
+		goto exit;
+	}
+	writer_args.sfd[1] = reader_args[1].sfd[0] = ds1_io_sfd;
 
-	replica_io_addr.sin_family = AF_INET;
-	replica_io_addr.sin_addr.s_addr = inet_addr(mgmt_ack->ip);
-	replica_io_addr.sin_port = htons(mgmt_ack->port);
-retry:
-	/* Data connection for ds0 */
-	io_sfd = create_and_bind("", B_FALSE, B_FALSE);
-	if (io_sfd == -1) {
-		printf("Socket creation failed with errno:%d\n", errno);
-		goto start;
+	/* Mgmt Handshake and IO-conn for replica ds2 */
+	ds2_io_sfd = zrepl_utest_mgmt_hs_io_conn(ds2, mgmt_fd);
+	if (ds2_io_sfd == -1) {
+		goto exit;
 	}
-	rc = connect(io_sfd, (struct sockaddr *)&replica_io_addr,
-	    sizeof (replica_io_addr));
-	if (rc == -1) {
-		printf("Failed to connect to replica-IO port"
-		    " with errno:%d\n", errno);
-		close(io_sfd);
-		sleep(1);
-		goto retry;
-	}
-	printf("Connect to replica IO port is successfully\n");
 
-	writer_args.sfd[0] = reader_args[0].sfd[0] = io_sfd;
-
-	/* Data connection for ds1  */
-	io_sfd1 = create_and_bind("", B_FALSE, B_FALSE);
-	if (io_sfd1 == -1) {
-		printf("Socket creation failed with errno:%d\n", errno);
-		goto start;
+	/* Mgmt Handshake and IO-conn for replica ds3 */
+	ds3_io_sfd = zrepl_utest_mgmt_hs_io_conn(ds3, mgmt_fd);
+	if (ds3_io_sfd == -1) {
+		goto exit;
 	}
-	rc = connect(io_sfd1, (struct sockaddr *)&replica_io_addr,
-	    sizeof (replica_io_addr));
-	if (rc == -1) {
-		printf("Failed to connect to replica-IO port"
-		    " with errno:%d\n", errno);
-		sleep(1);
-		close(io_sfd1);
-		goto retry;
-	}
-	printf("Connect to replica IO port is successfully\n");
 
 	/* Check status of replica ds0 */
-	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	rc = zrepl_utest_get_replica_status(ds, mgmt_fd, &status_ack);
 	if (rc == -1) {
 		goto exit;
 	}
@@ -883,12 +889,13 @@ retry:
 	 * If replica ds0 status is not healthy then trigger rebuild
 	 * on ds0, without any target(healthy replica).
 	 */
+	mgmt_ack = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
 	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
 		printf("Volume:%s health status: NOT_HEALTHY\n", ds);
 		strncpy(mgmt_ack->dw_volname, ds,
 		    sizeof (mgmt_ack->dw_volname));
 		strncpy(mgmt_ack->volname, "", sizeof (mgmt_ack->volname));
-		rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack,
+		rc = zrepl_utest_replica_rebuild_start(mgmt_fd, mgmt_ack,
 		    sizeof (mgmt_ack_t));
 		if (rc == -1) {
 			goto exit;
@@ -896,7 +903,7 @@ retry:
 	}
 
 check_status:
-	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	rc = zrepl_utest_get_replica_status(ds, mgmt_fd, &status_ack);
 	if (rc == -1) {
 		goto exit;
 	}
@@ -908,27 +915,26 @@ check_status:
 	printf("Volume:%s health status: HEALTHY\n", ds);
 
 	/* Start writing data to both replicas */
-	writer_args.sfd[1] = reader_args[1].sfd[0] = io_sfd1;
 	writer = zk_thread_create(NULL, 0,
 	    (thread_func_t)writer_thread, &writer_args, 0, NULL,
 	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
 	num_threads++;
-	printf("Write_func thread created successfully\n");
 
 	reader[0] = zk_thread_create(NULL, 0, (thread_func_t)reader_thread,
 	    &reader_args[0], 0, NULL, TS_RUN, 0, PTHREAD_CREATE_DETACHED);
 	num_threads++;
-	printf("Reader_func thread-0 created successfully\n");
 
 	reader[1] = zk_thread_create(NULL, 0, (thread_func_t)reader_thread,
 	    &reader_args[1], 0, NULL, TS_RUN, 0, PTHREAD_CREATE_DETACHED);
 	num_threads++;
-	printf("Reader_func thread-1 created successfully\n");
+
+	/* Let's wait for threads to be done */
 	mutex_enter(&mtx);
 	while (threads_done != num_threads)
 		cv_wait(&cv, &mtx);
 	mutex_exit(&mtx);
 	num_threads = threads_done = 0;
+
 	/* Start rebuilding operation on ds1 from ds0 */
 
 	/*
@@ -936,47 +942,19 @@ check_status:
 	 * to healthy replica ds0 and get rebuild_io port
 	 * and ip from healthy replica ds0.
 	 */
-	hdr.version = REPLICA_VERSION;
-	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
-	hdr.len = strlen(ds)+1;
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	mgmt_ack_ds1 = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
+	count = zrepl_utest_prepare_for_rebuild(ds, ds1, mgmt_fd,
+	    mgmt_ack_ds1);
 	if (count == -1) {
 		printf("Prepare_for_rebuild: sending hdr failed\n");
 		goto exit;
 	}
 
-	count = write(new_fd, ds, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: sending volname failed\n");
-		goto exit;
-	}
-
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in hdr read\n");
-		goto exit;
-	}
-
-	count = read(new_fd, (void *)mgmt_ack, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
-		goto exit;
-	}
-
-	/* Copy downgraded replica (ds1) name in mgmt_ack */
-	strncpy(mgmt_ack->dw_volname, ds1, sizeof (mgmt_ack->dw_volname));
-
-	printf("Replica being rebuild is: %s\n", mgmt_ack->dw_volname);
-	printf("Replica helping rebuild is: %s\n", mgmt_ack->volname);
-	printf("Rebuilding IP address: %s\n", mgmt_ack->ip);
-	printf("Rebuilding Port: %d\n", mgmt_ack->port);
-
 	/*
 	 * Start rebuild process on downgraded replica ds1
 	 * by sharing IP and rebuild_Port info with ds1.
 	 */
-	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack,
+	rc = zrepl_utest_replica_rebuild_start(mgmt_fd, mgmt_ack_ds1,
 	    sizeof (mgmt_ack_t));
 	if (rc == -1) {
 		goto exit;
@@ -985,7 +963,7 @@ check_status:
 	 * Check rebuild status of of downgrade replica ds1.
 	 */
 status_check:
-	count = zrepl_utest_get_replica_status(ds1, new_fd, &status_ack);
+	count = zrepl_utest_get_replica_status(ds1, mgmt_fd, &status_ack);
 	if (count == -1) {
 		goto exit;
 	}
@@ -1017,44 +995,18 @@ status_check:
 	 * and ip. Copy it to mgmt_ack_ds2.
 	 */
 	mgmt_ack_ds2 = umem_alloc(sizeof (mgmt_ack_t) * 2, UMEM_NOFAIL);
-	bcopy(mgmt_ack, mgmt_ack_ds2, sizeof (mgmt_ack_t));
-
-	/* Modify dw_replica name to ds2 now */
-	strncpy(mgmt_ack_ds2->dw_volname, ds2,
-	    sizeof (mgmt_ack_ds2->dw_volname));
-
-	hdr.version = REPLICA_VERSION;
-	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
-	hdr.len = strlen(ds1)+1;
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	p = mgmt_ack_ds2;
+	count = zrepl_utest_prepare_for_rebuild(ds, ds2, mgmt_fd, p);
 	if (count == -1) {
 		printf("Prepare_for_rebuild: sending hdr failed\n");
 		goto exit;
 	}
-
-	count = write(new_fd, ds1, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: sending volname failed\n");
-		goto exit;
-	}
-
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in hdr read\n");
-		goto exit;
-	}
-
-	count = read(new_fd, (void *)mgmt_ack, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
-		goto exit;
-	}
-	mgmt_ack_t *p = mgmt_ack_ds2;
 	p++;
-	bcopy(mgmt_ack, p, sizeof (mgmt_ack_t));
-	/* Modify dw_replica name to ds2 now */
-	strncpy(p->dw_volname, ds2, sizeof (p->dw_volname));
+	count = zrepl_utest_prepare_for_rebuild(ds1, ds2, mgmt_fd, p);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
+	}
 
 	p = mgmt_ack_ds2;
 	for (i = 0; i < 2; i++) {
@@ -1069,7 +1021,7 @@ status_check:
 	 * Start rebuild process on downgraded replica ds2
 	 * by sharing IP and rebuild_Port info with ds2.
 	 */
-	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack_ds2,
+	rc = zrepl_utest_replica_rebuild_start(mgmt_fd, mgmt_ack_ds2,
 	    sizeof (mgmt_ack_t) * 2);
 	if (rc == -1) {
 		goto exit;
@@ -1078,7 +1030,7 @@ status_check:
 	 * Check rebuild status of ds2.
 	 */
 status_check1:
-	count = zrepl_utest_get_replica_status(ds2, new_fd, &status_ack);
+	count = zrepl_utest_get_replica_status(ds2, mgmt_fd, &status_ack);
 	if (count == -1) {
 		goto exit;
 	}
@@ -1098,54 +1050,38 @@ status_check1:
 	 * Copy that too to mgmt_ack_ds3.
 	 */
 	mgmt_ack_ds3 = umem_alloc(sizeof (mgmt_ack_t) * 3, UMEM_NOFAIL);
-	bcopy(mgmt_ack_ds2, mgmt_ack_ds3, sizeof (mgmt_ack_t) * 2);
 
-	hdr.version = REPLICA_VERSION;
-	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
-	hdr.len = strlen(ds2)+1;
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	p = mgmt_ack_ds3;
+	count = zrepl_utest_prepare_for_rebuild(ds, ds3, mgmt_fd, p);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
+	}
+	p++;
+	count = zrepl_utest_prepare_for_rebuild(ds1, ds3, mgmt_fd, p);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
+	}
+	p++;
+	count = zrepl_utest_prepare_for_rebuild(ds2, ds3, mgmt_fd, p);
 	if (count == -1) {
 		printf("Prepare_for_rebuild: sending hdr failed\n");
 		goto exit;
 	}
 
-	count = write(new_fd, ds2, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: sending volname failed\n");
-		goto exit;
-	}
-
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in hdr read\n");
-		goto exit;
-	}
-
-	count = read(new_fd, (void *)mgmt_ack, hdr.len);
-	if (count == -1) {
-		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
-		goto exit;
-	}
-
-	p = mgmt_ack_ds3;
-	p++; p++;
-	bcopy(mgmt_ack, p, sizeof (mgmt_ack_t));
-
 	int original_port = 0;
 	p = mgmt_ack_ds3;
 	for (i = 0; i < 3; i++) {
-		/* Modify downgrade replica and set it to ds3 */
-		strncpy(p->dw_volname, ds3, sizeof (p->dw_volname));
-		printf("Replica being rebuild is: %s\n", p->dw_volname);
-		printf("Replica helping rebuild is: %s\n", p->volname);
-		printf("Rebuilding IP address: %s\n", p->ip);
-		printf("Rebuilding Port: %d\n", p->port);
 		if (i == 2) {
 			/* For ds2, assign wrong port, so that rebuild fail */
 			original_port = p->port;
 			p->port = 9999;
 		}
+		printf("Replica being rebuild is: %s\n", p->dw_volname);
+		printf("Replica helping rebuild is: %s\n", p->volname);
+		printf("Rebuilding IP address: %s\n", p->ip);
+		printf("Rebuilding Port: %d\n", p->port);
 		p++;
 	}
 
@@ -1153,7 +1089,7 @@ status_check1:
 	 * Start rebuild process on downgraded replica ds3
 	 * by sharing IP and rebuild_Port info with ds3.
 	 */
-	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack_ds3,
+	rc = zrepl_utest_replica_rebuild_start(mgmt_fd, mgmt_ack_ds3,
 	    sizeof (mgmt_ack_t) * 3);
 	if (rc == -1) {
 		goto exit;
@@ -1162,7 +1098,7 @@ status_check1:
 	 * Check rebuild status of ds3.
 	 */
 status_check2:
-	count = zrepl_utest_get_replica_status(ds3, new_fd, &status_ack);
+	count = zrepl_utest_get_replica_status(ds3, mgmt_fd, &status_ack);
 	if (count == -1) {
 		goto exit;
 	}
@@ -1173,7 +1109,9 @@ status_check2:
 	}
 
 	printf("Rebuilding failed on Replica:%s\n", ds3);
+	sleep(10);
 
+	printf("\n\n");
 	/* Lets retry to rebuild on ds3 with correct info */
 	p = mgmt_ack_ds3;
 	for (i = 0; i < 3; i++) {
@@ -1181,6 +1119,10 @@ status_check2:
 			/* For ds2, re-assign right port */
 			p->port = original_port;
 		}
+		printf("Replica being rebuild is: %s\n", p->dw_volname);
+		printf("Replica helping rebuild is: %s\n", p->volname);
+		printf("Rebuilding IP address: %s\n", p->ip);
+		printf("Rebuilding Port: %d\n", p->port);
 		p++;
 	}
 
@@ -1188,7 +1130,7 @@ status_check2:
 	 * Start rebuild process on downgraded replica ds3
 	 * by sharing IP and rebuild_Port info with ds3.
 	 */
-	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack_ds3,
+	rc = zrepl_utest_replica_rebuild_start(mgmt_fd, mgmt_ack_ds3,
 	    sizeof (mgmt_ack_t) * 3);
 	if (rc == -1) {
 		goto exit;
@@ -1197,7 +1139,7 @@ status_check2:
 	 * Check rebuild status of ds3.
 	 */
 status_check3:
-	count = zrepl_utest_get_replica_status(ds3, new_fd, &status_ack);
+	count = zrepl_utest_get_replica_status(ds3, mgmt_fd, &status_ack);
 	if (count == -1) {
 		goto exit;
 	}
@@ -1212,17 +1154,25 @@ exit:
 	if (sfd != -1)
 		close(sfd);
 
-	if (new_fd != -1)
-		close(new_fd);
+	if (mgmt_fd != -1)
+		close(mgmt_fd);
 
-	if (io_sfd != -1)
-		close(io_sfd);
+	if (ds0_io_sfd != -1)
+		close(ds0_io_sfd);
 
-	if (io_sfd1 != -1)
-		close(io_sfd1);
+	if (ds1_io_sfd != -1)
+		close(ds1_io_sfd);
+
+	if (ds2_io_sfd != -1)
+		close(ds2_io_sfd);
+
+	if (ds3_io_sfd != -1)
+		close(ds3_io_sfd);
 
 	if (mgmt_ack != NULL)
 		umem_free(mgmt_ack, sizeof (mgmt_ack_t));
+	if (mgmt_ack_ds1 != NULL)
+		umem_free(mgmt_ack_ds1, sizeof (mgmt_ack_t));
 	if (mgmt_ack_ds2 != NULL)
 		umem_free(mgmt_ack_ds2, sizeof (mgmt_ack_t) * 2);
 	if (mgmt_ack_ds3 != NULL)

--- a/cmd/uzfs_test/zrepl_utest.c
+++ b/cmd/uzfs_test/zrepl_utest.c
@@ -16,6 +16,8 @@
 
 char *tgt_port = "6060";
 char *ds1 = "ds1";
+char *ds2 = "ds2";
+char *ds3 = "ds3";
 static uint64_t last_io_seq_sent;
 
 struct data_io {
@@ -44,6 +46,132 @@ zrepl_verify_data(char *p, int size)
 		if (p[i] != 'C') {
 			return (-1);
 		}
+	}
+	return (0);
+}
+
+int
+zrepl_compare_data(char *buf1, char *buf2, int size)
+{
+
+	int i;
+
+	for (i = 0; i < size; i++) {
+		if (buf1[i] != buf2[i]) {
+			return (-1);
+		}
+	}
+	return (0);
+}
+
+int
+zrepl_utest_replica_handshake(char *volname, int fd,
+    mgmt_ack_t *mgmt_ack)
+{
+	int count = 0;
+	zvol_io_hdr_t hdr;
+	bzero(&hdr, sizeof (hdr));
+
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
+	hdr.len = strlen(volname) + 1;
+
+	count = write(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("During handshake, Write error\n");
+		return (count);
+	}
+
+	count = write(fd, volname, hdr.len);
+	if (count == -1) {
+		printf("During volname send, Write error\n");
+		return (count);
+	}
+
+	count = read(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("During HDR read, Read error\n");
+		return (count);
+	}
+
+	if (hdr.status == ZVOL_OP_STATUS_FAILED) {
+		printf("Header status is failed\n");
+		return (-1);
+	}
+
+	count = read(fd, (void *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("During mgmt Read error\n");
+		return (count);
+	}
+	return (0);
+}
+
+int
+zrepl_utest_get_replica_status(char *volname, int fd,
+    zrepl_status_ack_t *status_ack)
+{
+	int count = 0;
+	zvol_io_hdr_t hdr;
+
+	bzero(&hdr, sizeof (hdr));
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_REPLICA_STATUS;
+	hdr.len = strlen(volname) + 1;
+
+	printf("Check health status of volume:%s\n", volname);
+	count = write(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Health status: sending hdr failed\n");
+		return (-1);
+	}
+
+	count = write(fd, volname, hdr.len);
+	if (count == -1) {
+		printf("Health status: sending volname failed\n");
+		return (-1);
+	}
+
+	count = read(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Health status: error in hdr read\n");
+		return (-1);
+	}
+
+	if (hdr.status != ZVOL_OP_STATUS_OK) {
+		printf("Health status: response failed\n");
+		return (-1);
+	}
+
+	count = read(fd, (void *)status_ack, sizeof (zrepl_status_ack_t));
+	if (count == -1) {
+		printf("Health status: error in statuc_ack read\n");
+		return (-1);
+	}
+	return (0);
+}
+
+int
+zrepl_utest_replica_rebuild_start(int fd, mgmt_ack_t *mgmt_ack,
+    int size)
+{
+	int count = 0;
+	zvol_io_hdr_t hdr;
+
+	bzero(&hdr, sizeof (hdr));
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_START_REBUILD;
+	hdr.len = size;
+	count = write(fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Start_rebuild: sending hdr failed\n");
+		return (count);
+	}
+
+	count = write(fd, (char *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("start_rebuild: sending volname failed\n");
+		return (count);
 	}
 	return (0);
 }
@@ -182,7 +310,7 @@ writer_thread(void *arg)
 	}
 
 	if (warg->rebuild_test == B_TRUE) {
-		io->hdr.len    = strlen(ds1) + 1;
+		io->hdr.len = strlen(ds1) + 1;
 		strncpy(io->buf, ds1, io->hdr.len);
 
 		count = write(sfd1, (void *)&(io->hdr), sizeof (zvol_io_hdr_t));
@@ -301,6 +429,138 @@ exit:
 	zk_thread_exit();
 }
 
+static void
+replica_data_verify_thread(void *arg)
+{
+
+	int i = 0;
+	char *p;
+	char *buf1;
+	char *buf2;
+	int sfd, sfd1;
+	int count = 0;
+	int nbytes = 0;
+	int read_bytes = 0;
+	kmutex_t *mtx;
+	kcondvar_t *cv;
+	zvol_io_hdr_t hdr;
+	struct zvol_io_rw_hdr *read_hdr1;
+	struct zvol_io_rw_hdr *read_hdr2;
+	int *threads_done;
+	worker_args_t *warg = (worker_args_t *)arg;
+
+	sfd = warg->sfd[0];
+	sfd1 = warg->sfd[1];
+	mtx = warg->mtx;
+	cv = warg->cv;
+	threads_done = warg->threads_done;
+
+	/* Read and validate data */
+	i = 0;
+	nbytes = 0;
+	while (i < warg->max_iops) {
+		bzero(&hdr, sizeof (zvol_io_hdr_t));
+
+		/* Construct hdr for read request */
+		hdr.version = REPLICA_VERSION;
+		hdr.opcode = ZVOL_OPCODE_READ;
+		hdr.io_seq = i;
+		hdr.len    = warg->io_block_size;
+		hdr.offset = nbytes;
+
+		/* Read request to replica ds0 */
+		count = write(sfd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+		if (count == -1) {
+			printf("Write error\n");
+			break;
+		}
+
+		/* Read request to replica ds1 */
+		count = write(sfd1, (void *)&hdr, sizeof (zvol_io_hdr_t));
+		if (count == -1) {
+			printf("Write error\n");
+			break;
+		}
+
+		nbytes += warg->io_block_size;
+		i++;
+
+		/* Read hdr from replica ds0(sfd) */
+		count = read(sfd, &hdr, sizeof (zvol_io_hdr_t));
+		if (count != sizeof (zvol_io_hdr_t)) {
+			printf("Header read error\n");
+			break;
+		}
+
+		read_bytes = hdr.len;
+		buf1 = kmem_alloc(read_bytes, KM_SLEEP);
+		p = buf1;
+
+		/* Read data from replica ds0(sfd) */
+		while (read_bytes) {
+			count = read(sfd, (void *)p, nbytes);
+			if (count < 0) {
+				printf("\n");
+				printf("Read error in reader_thread "
+				    "reading data\n");
+			}
+			p += count;
+			read_bytes -= count;
+		}
+
+		/* Read hdr from replica ds1(sfd1) */
+		count = read(sfd1, &hdr, sizeof (zvol_io_hdr_t));
+		if (count != sizeof (zvol_io_hdr_t)) {
+			printf("Meta data header read error\n");
+			break;
+		}
+
+		read_bytes = hdr.len;
+		buf2 = kmem_alloc(read_bytes, KM_SLEEP);
+		p = buf2;
+
+		/* Read data from replica ds1(sfd1) */
+		while (read_bytes) {
+			count = read(sfd1, (void *)p, nbytes);
+			if (count < 0) {
+				printf("\n");
+				printf("Read error in reader_thread "
+				    "reading data\n");
+			}
+			p += count;
+			read_bytes -= count;
+		}
+
+		read_hdr1 = (struct zvol_io_rw_hdr *)buf1;
+		read_hdr2 = (struct zvol_io_rw_hdr *)buf2;
+		/* Compare io_num, should be same */
+		if (read_hdr1->io_num != read_hdr2->io_num) {
+			ASSERT(!"IO Number mismatch\n");
+		}
+
+		/* Compare len, should be same */
+		if (read_hdr1->len != read_hdr2->len) {
+			ASSERT(!"IO length mismatch\n");
+		}
+
+		count = zrepl_compare_data(buf1 +
+		    sizeof (struct zvol_io_rw_hdr),
+		    buf2 + sizeof (struct zvol_io_rw_hdr), read_hdr1->len);
+		if (count != 0) {
+			ASSERT(!"Data mistmach mismatch\n");
+		}
+
+		kmem_free(buf1, hdr.len);
+		kmem_free(buf2, hdr.len);
+	}
+
+	mutex_enter(mtx);
+	*threads_done = *threads_done + 1;
+	cv_signal(cv);
+	mutex_exit(mtx);
+	zk_thread_exit();
+}
+
 void
 zrepl_utest(void *arg)
 {
@@ -310,12 +570,11 @@ zrepl_utest(void *arg)
 	int  io_sfd, new_fd;
 	int threads_done = 0;
 	int num_threads = 0;
-	int wrong_message = 1;
 	kthread_t *reader;
 	kthread_t *writer;
 	socklen_t in_len;
-	zvol_io_hdr_t hdr;
 	mgmt_ack_t mgmt_ack;
+	zrepl_status_ack_t status_ack;
 	struct sockaddr in_addr;
 	struct sockaddr_in replica_io_addr;
 	worker_args_t writer_args, reader_args;
@@ -366,48 +625,10 @@ start:
 		printf("Unable to accept\n");
 		goto exit;
 	}
-	printf("Connection accepted from replica successful\n");
 
-	hdr.version = REPLICA_VERSION;
-	if (wrong_message) {
-		hdr.opcode = -1;
-		wrong_message = 0;
-	} else {
-		hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
-	}
-	hdr.len = strlen(ds)+1;
-	printf("Op code sent %d with len:%ld\n", hdr.opcode, hdr.len);
-
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	printf("Connection accepted from replica successfully\n");
+	count = zrepl_utest_replica_handshake(ds, new_fd, &mgmt_ack);
 	if (count == -1) {
-		printf("During hand shake Write error\n");
-		goto exit;
-	}
-	printf("header has been sent with count %d\n", count);
-
-	count = write(new_fd, ds, hdr.len);
-	if (count == -1) {
-		printf("During name send Write error\n");
-		goto exit;
-	}
-	printf("Volname has been sent with count %d\n", count);
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("During hdr Read error\n");
-		goto exit;
-	}
-	printf("Header has read with count %d\n", count);
-
-	if (hdr.status == ZVOL_OP_STATUS_FAILED) {
-		close(new_fd);
-		printf("Header status is failed\n");
-		goto start;
-	}
-
-	count = read(new_fd, (void *)&mgmt_ack, sizeof (mgmt_ack));
-	if (count == -1) {
-		printf("During mgmt Read error\n");
 		goto exit;
 	}
 
@@ -438,6 +659,33 @@ retry:
 	printf("Connect to replica IO port is successfully\n");
 
 	writer_args.sfd[0] = reader_args.sfd[0] = io_sfd;
+	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	if (rc == -1) {
+		goto exit;
+	}
+
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		printf("Volume:%s health status: NOT_HEALTHY\n", ds);
+		strncpy(mgmt_ack.dw_volname, ds, sizeof (mgmt_ack.dw_volname));
+		strncpy(mgmt_ack.volname, "", sizeof (mgmt_ack.volname));
+		rc = zrepl_utest_replica_rebuild_start(new_fd, &mgmt_ack,
+		    sizeof (mgmt_ack_t));
+		if (rc == -1) {
+			goto exit;
+		}
+	}
+
+check_status:
+	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	if (rc == -1) {
+		goto exit;
+	}
+
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		sleep(1);
+		goto check_status;
+	}
+	printf("Volume:%s health status: HEALTHY\n", ds);
 	writer = zk_thread_create(NULL, 0,
 	    (thread_func_t)writer_thread, &writer_args, 0, NULL,
 	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
@@ -466,21 +714,51 @@ exit:
 	}
 }
 
+/*
+ * Rebuilding downgraded replica test case. It covers following case:
+ * =====Rebuild success case=====
+ * Details:
+ * - Two replicas, ds0 a healthy while ds1 will be downgrade replica
+ * - Replica ds0 is marked as healthy replica in the beginning
+ * - 10K IOs of size 4k pumped into ds0
+ * - 5k IOs of size 4k (with same data) will be pumped into ds1
+ * - Trigger rebuild workflow on ds1 using IP + Rebuild_port of ds0
+ * - Wait for ds1 to be marked healthy
+ * - Now read each block from ds0 and ds1, compare IO_seq and data.
+ *
+ * =====Multiple Rebuild success case=====
+ * Details:
+ * - Two replicas ds0 and ds1 are healthy
+ * - ds2 downgrade replica
+ * - Trigger rebuild workflow on ds2 using IP + Rebuild_port of ds0 & ds1
+ * - Rebuild will be triggered successfully on ds0 & ds1
+ * - Wait till ds2 become healthy
+ *
+ * =====Rebuild failure case=====
+ * - Replicas ds0i, ds1 and ds2 are healthy
+ * - ds3 downgrade replica
+ * - Trigger rebuild workflow on ds3 using IP + Rebuild_port of ds0, ds1 and ds2
+ * - Pass wrong IP address for ds2 so that connection got failed
+ * - Rebuild will be triggered successfully on ds0 and ds1 but would fail on ds2
+ * - Since rebuild would fail on ds2, all rebuild operation happening in
+ *   parallel should be stopped and ds2 should be left in downgrade mode.
+ */
 void
 zrepl_rebuild_test(void *arg)
 {
 	kmutex_t mtx;
 	kcondvar_t cv;
-	int count, sfd, rc;
+	int i, count, sfd, rc;
 	int  io_sfd, io_sfd1, new_fd;
 	int threads_done = 0;
 	int num_threads = 0;
-	int wrong_message = 1;
 	kthread_t *reader[2];
 	kthread_t *writer;
 	socklen_t in_len;
 	zvol_io_hdr_t hdr;
 	mgmt_ack_t *mgmt_ack = NULL;
+	mgmt_ack_t *mgmt_ack_ds2 = NULL;
+	mgmt_ack_t *mgmt_ack_ds3 = NULL;
 	struct sockaddr in_addr;
 	zrepl_status_ack_t status_ack;
 	struct sockaddr_in replica_io_addr;
@@ -488,7 +766,7 @@ zrepl_rebuild_test(void *arg)
 
 	io_block_size = 4096;
 	active_size = 0;
-	max_iops = 10000;
+	max_iops = 2000;
 	pool = "testp";
 	ds = "ds0";
 	ds1 = "ds1";
@@ -518,7 +796,7 @@ zrepl_rebuild_test(void *arg)
 	reader_args[1].cv = &cv;
 	reader_args[1].io_block_size = io_block_size;
 	reader_args[1].active_size = active_size;
-	reader_args[1].max_iops = max_iops/2;
+	reader_args[1].max_iops = max_iops / 2;
 	reader_args[1].rebuild_test = B_TRUE;
 
 	sfd = create_and_bind(tgt_port, B_TRUE, B_FALSE);
@@ -540,50 +818,12 @@ start:
 		printf("Unable to accept\n");
 		goto exit;
 	}
-	printf("Connection accepted from replica successful\n");
+	printf("Connection accepted from replica successfully\n");
 
-	hdr.version = REPLICA_VERSION;
-	if (wrong_message) {
-		hdr.opcode = -1;
-		wrong_message = 0;
-	} else {
-		hdr.opcode = ZVOL_OPCODE_HANDSHAKE;
-	}
-	hdr.len = strlen(ds)+1;
-	printf("Op code sent %d with len:%ld\n", hdr.opcode, hdr.len);
-
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("During hand shake Write error\n");
-		goto exit;
-	}
-	printf("header has been sent with count %d\n", count);
-
-	count = write(new_fd, ds, hdr.len);
-	if (count == -1) {
-		printf("During name send Write error\n");
-		goto exit;
-	}
-	printf("Volname has been sent with count %d\n", count);
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("During hdr Read error\n");
-		goto exit;
-	}
-	printf("Header has read with count %d\n", count);
-
-	if (hdr.status == ZVOL_OP_STATUS_FAILED) {
-		close(new_fd);
-		printf("Header status is failed\n");
-		goto start;
-	}
-
+	/* Handshake for replica ds0 */
 	mgmt_ack = umem_alloc(sizeof (mgmt_ack_t), UMEM_NOFAIL);
-
-	count = read(new_fd, (void *)mgmt_ack, hdr.len);
+	count = zrepl_utest_replica_handshake(ds, new_fd, mgmt_ack);
 	if (count == -1) {
-		printf("During mgmt Read error\n");
 		goto exit;
 	}
 
@@ -597,6 +837,7 @@ start:
 	replica_io_addr.sin_addr.s_addr = inet_addr(mgmt_ack->ip);
 	replica_io_addr.sin_port = htons(mgmt_ack->port);
 retry:
+	/* Data connection for ds0 */
 	io_sfd = create_and_bind("", B_FALSE, B_FALSE);
 	if (io_sfd == -1) {
 		printf("Socket creation failed with errno:%d\n", errno);
@@ -615,6 +856,7 @@ retry:
 
 	writer_args.sfd[0] = reader_args[0].sfd[0] = io_sfd;
 
+	/* Data connection for ds1  */
 	io_sfd1 = create_and_bind("", B_FALSE, B_FALSE);
 	if (io_sfd1 == -1) {
 		printf("Socket creation failed with errno:%d\n", errno);
@@ -631,6 +873,41 @@ retry:
 	}
 	printf("Connect to replica IO port is successfully\n");
 
+	/* Check status of replica ds0 */
+	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	if (rc == -1) {
+		goto exit;
+	}
+
+	/*
+	 * If replica ds0 status is not healthy then trigger rebuild
+	 * on ds0, without any target(healthy replica).
+	 */
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		printf("Volume:%s health status: NOT_HEALTHY\n", ds);
+		strncpy(mgmt_ack->dw_volname, ds,
+		    sizeof (mgmt_ack->dw_volname));
+		strncpy(mgmt_ack->volname, "", sizeof (mgmt_ack->volname));
+		rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack,
+		    sizeof (mgmt_ack_t));
+		if (rc == -1) {
+			goto exit;
+		}
+	}
+
+check_status:
+	rc = zrepl_utest_get_replica_status(ds, new_fd, &status_ack);
+	if (rc == -1) {
+		goto exit;
+	}
+
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		sleep(1);
+		goto check_status;
+	}
+	printf("Volume:%s health status: HEALTHY\n", ds);
+
+	/* Start writing data to both replicas */
 	writer_args.sfd[1] = reader_args[1].sfd[0] = io_sfd1;
 	writer = zk_thread_create(NULL, 0,
 	    (thread_func_t)writer_thread, &writer_args, 0, NULL,
@@ -651,13 +928,13 @@ retry:
 	while (threads_done != num_threads)
 		cv_wait(&cv, &mtx);
 	mutex_exit(&mtx);
-	cv_destroy(&cv);
-	mutex_destroy(&mtx);
-	/* Start rebuilding operation */
+	num_threads = threads_done = 0;
+	/* Start rebuilding operation on ds1 from ds0 */
+
 	/*
-	 * Step1: Send ZVOL_OPCODE_PREPARE_FOR_REBUILD message to
-	 * healthy replica and get rebuild_io port and ip from healthy
-	 * replica. ds0 is healthy replica in this case.
+	 * Send ZVOL_OPCODE_PREPARE_FOR_REBUILD op_code
+	 * to healthy replica ds0 and get rebuild_io port
+	 * and ip from healthy replica ds0.
 	 */
 	hdr.version = REPLICA_VERSION;
 	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
@@ -687,64 +964,29 @@ retry:
 		goto exit;
 	}
 
+	/* Copy downgraded replica (ds1) name in mgmt_ack */
 	strncpy(mgmt_ack->dw_volname, ds1, sizeof (mgmt_ack->dw_volname));
-	printf("Healthy replica: %s\n", mgmt_ack->volname);
+
+	printf("Replica being rebuild is: %s\n", mgmt_ack->dw_volname);
+	printf("Replica helping rebuild is: %s\n", mgmt_ack->volname);
 	printf("Rebuilding IP address: %s\n", mgmt_ack->ip);
 	printf("Rebuilding Port: %d\n", mgmt_ack->port);
-	printf("Downgraded replica: %s\n", mgmt_ack->dw_volname);
-	/*
-	 * Step2: Send Rebuild IP address and Port to downgrade
-	 * replica. In this case ds1 is downgraded replica.
-	 */
-	hdr.version = REPLICA_VERSION;
-	hdr.opcode = ZVOL_OPCODE_START_REBUILD;
-	hdr.len = sizeof (mgmt_ack_t);
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Start_rebuild: sending hdr failed\n");
-		goto exit;
-	}
 
-	count = write(new_fd, (char *)mgmt_ack, hdr.len);
-	if (count == -1) {
-		printf("start_rebuild: sending volname failed\n");
+	/*
+	 * Start rebuild process on downgraded replica ds1
+	 * by sharing IP and rebuild_Port info with ds1.
+	 */
+	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack,
+	    sizeof (mgmt_ack_t));
+	if (rc == -1) {
 		goto exit;
 	}
-	printf("Rebuilding on volume:%s started ....\n", ds1);
 	/*
-	 * Step3: Check rebuild status of ds1.
+	 * Check rebuild status of of downgrade replica ds1.
 	 */
 status_check:
-	printf("Lets wait for healthy status of volume:%s\n", ds1);
-	hdr.version = REPLICA_VERSION;
-	hdr.opcode = ZVOL_OPCODE_REPLICA_STATUS;
-	hdr.len = strlen(ds1) + 1;
-	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	count = zrepl_utest_get_replica_status(ds1, new_fd, &status_ack);
 	if (count == -1) {
-		printf("Rebuild_status: sending hdr failed\n");
-		goto exit;
-	}
-
-	count = write(new_fd, ds1, hdr.len);
-	if (count == -1) {
-		printf("Rebuild_status: sending volname failed\n");
-		goto exit;
-	}
-
-	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
-	if (count == -1) {
-		printf("Rebuild_status: error in hdr read\n");
-		goto exit;
-	}
-
-	if (hdr.status != ZVOL_OP_STATUS_OK) {
-		printf("Rebuild_status: response failed\n");
-		goto exit;
-	}
-
-	count = read(new_fd, (void *)&status_ack, hdr.len);
-	if (count == -1) {
-		printf("Rebuild_status: error in mgmt_ack read\n");
 		goto exit;
 	}
 
@@ -752,15 +994,189 @@ status_check:
 		sleep(1);
 		goto status_check;
 	}
-exit:
-	printf("Replica is healthy now\n");
-	if (sfd != -1) {
-		close(sfd);
+	printf("Replica:%s is healthy now\n", ds1);
+
+	/* Verify if the data is same on both replica or not */
+	writer = zk_thread_create(NULL, 0,
+	    (thread_func_t)replica_data_verify_thread, &writer_args, 0, NULL,
+	    TS_RUN, 0, PTHREAD_CREATE_DETACHED);
+	num_threads++;
+	mutex_enter(&mtx);
+	while (threads_done != num_threads)
+		cv_wait(&cv, &mtx);
+	mutex_exit(&mtx);
+	cv_destroy(&cv);
+	mutex_destroy(&mtx);
+
+	/* Start rebuilding operation on ds2 from ds0 and ds1 */
+
+	/*
+	 * mgmt_ack has IP + Rebuild_port for ds0, copy it
+	 * to mgmt_ack_ds2, send ZVOL_OPCODE_PREPARE_FOR_REBUILD
+	 * op_code to healthy replicas ds1, get rebuild_io port
+	 * and ip. Copy it to mgmt_ack_ds2.
+	 */
+	mgmt_ack_ds2 = umem_alloc(sizeof (mgmt_ack_t) * 2, UMEM_NOFAIL);
+	bcopy(mgmt_ack, mgmt_ack_ds2, sizeof (mgmt_ack_t));
+
+	/* Modify dw_replica name to ds2 now */
+	strncpy(mgmt_ack_ds2->dw_volname, ds2,
+	    sizeof (mgmt_ack_ds2->dw_volname));
+
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
+	hdr.len = strlen(ds1)+1;
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
 	}
 
-	if (new_fd != -1) {
-		close(new_fd);
+	count = write(new_fd, ds1, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending volname failed\n");
+		goto exit;
 	}
+
+
+	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in hdr read\n");
+		goto exit;
+	}
+
+	count = read(new_fd, (void *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
+		goto exit;
+	}
+	mgmt_ack_t *p = mgmt_ack_ds2;
+	p++;
+	bcopy(mgmt_ack, p, sizeof (mgmt_ack_t));
+	/* Modify dw_replica name to ds2 now */
+	strncpy(p->dw_volname, ds2, sizeof (p->dw_volname));
+
+	p = mgmt_ack_ds2;
+	for (i = 0; i < 2; i++) {
+		printf("Replica being rebuild is: %s\n", p->dw_volname);
+		printf("Replica helping rebuild is: %s\n", p->volname);
+		printf("Rebuilding IP address: %s\n", p->ip);
+		printf("Rebuilding Port: %d\n", p->port);
+		p++;
+	}
+
+	/*
+	 * Start rebuild process on downgraded replica ds2
+	 * by sharing IP and rebuild_Port info with ds2.
+	 */
+	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack_ds2,
+	    sizeof (mgmt_ack_t) * 2);
+	if (rc == -1) {
+		goto exit;
+	}
+	/*
+	 * Check rebuild status of ds2.
+	 */
+status_check1:
+	count = zrepl_utest_get_replica_status(ds2, new_fd, &status_ack);
+	if (count == -1) {
+		goto exit;
+	}
+
+	if (status_ack.state != ZVOL_STATUS_HEALTHY) {
+		sleep(1);
+		goto status_check1;
+	}
+	printf("Replica:%s is healthy now\n", ds2);
+
+	/* Start rebuilding operation on ds3 from ds0, ds1 and ds2 */
+
+	/*
+	 * Copy mgmt_ack_ds2 to mgmt_ack_ds3, mgmt_ack_ds2 has
+	 * IP + rebuild_port info of ds0, ds1. Send
+	 * ZVOL_OPCODE_PREPARE_FOR_REBUILD op_code ds2.
+	 * Copy that too to mgmt_ack_ds3.
+	 */
+	mgmt_ack_ds3 = umem_alloc(sizeof (mgmt_ack_t) * 3, UMEM_NOFAIL);
+	bcopy(mgmt_ack_ds2, mgmt_ack_ds3, sizeof (mgmt_ack_t) * 2);
+
+	hdr.version = REPLICA_VERSION;
+	hdr.opcode = ZVOL_OPCODE_PREPARE_FOR_REBUILD;
+	hdr.len = strlen(ds2)+1;
+	count = write(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending hdr failed\n");
+		goto exit;
+	}
+
+	count = write(new_fd, ds2, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: sending volname failed\n");
+		goto exit;
+	}
+
+
+	count = read(new_fd, (void *)&hdr, sizeof (zvol_io_hdr_t));
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in hdr read\n");
+		goto exit;
+	}
+
+	count = read(new_fd, (void *)mgmt_ack, hdr.len);
+	if (count == -1) {
+		printf("Prepare_for_rebuild: error in mgmt_ack read\n");
+		goto exit;
+	}
+
+	p = mgmt_ack_ds3;
+	p++; p++;
+	bcopy(mgmt_ack, p, sizeof (mgmt_ack_t));
+
+	p = mgmt_ack_ds3;
+	for (i = 0; i < 3; i++) {
+		/* Modify downgrade replica and set it to ds3 */
+		strncpy(p->dw_volname, ds3, sizeof (p->dw_volname));
+		printf("Replica being rebuild is: %s\n", p->dw_volname);
+		printf("Replica helping rebuild is: %s\n", p->volname);
+		printf("Rebuilding IP address: %s\n", p->ip);
+		printf("Rebuilding Port: %d\n", p->port);
+		if (i == 2) {
+			/* For ds2, assign wrong port, so that rebuild fail */
+			p->port = 9999;
+		}
+		p++;
+	}
+
+	/*
+	 * Start rebuild process on downgraded replica ds3
+	 * by sharing IP and rebuild_Port info with ds3.
+	 */
+	rc = zrepl_utest_replica_rebuild_start(new_fd, mgmt_ack_ds3,
+	    sizeof (mgmt_ack_t) * 3);
+	if (rc == -1) {
+		goto exit;
+	}
+	/*
+	 * Check rebuild status of ds3.
+	 */
+status_check2:
+	count = zrepl_utest_get_replica_status(ds3, new_fd, &status_ack);
+	if (count == -1) {
+		goto exit;
+	}
+
+	if (status_ack.rebuild_status != ZVOL_REBUILDING_FAILED) {
+		sleep(1);
+		goto status_check2;
+	}
+
+	printf("Rebuilding failed on Replica:%s\n", ds3);
+exit:
+	if (sfd != -1)
+		close(sfd);
+
+	if (new_fd != -1)
+		close(new_fd);
 
 	if (io_sfd != -1)
 		close(io_sfd);
@@ -770,4 +1186,8 @@ exit:
 
 	if (mgmt_ack != NULL)
 		umem_free(mgmt_ack, sizeof (mgmt_ack_t));
+	if (mgmt_ack_ds2 != NULL)
+		umem_free(mgmt_ack_ds2, sizeof (mgmt_ack_t) * 2);
+	if (mgmt_ack_ds3 != NULL)
+		umem_free(mgmt_ack_ds3, sizeof (mgmt_ack_t) * 3);
 }

--- a/cmd/zrepl/data_conn.c
+++ b/cmd/zrepl/data_conn.c
@@ -208,8 +208,6 @@ uzfs_zvol_worker(void *arg)
 		case ZVOL_OPCODE_WRITE:
 			write = 1;
 			rc = uzfs_submit_writes(zinfo, zio_cmd);
-			zinfo->checkpointed_io_seq =
-			    zio_cmd->hdr.checkpointed_io_seq;
 			break;
 
 		case ZVOL_OPCODE_SYNC:
@@ -262,7 +260,8 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 	rebuild_thread_arg_t *rebuild_args = arg;
 	struct sockaddr_in replica_ip;
 
-	int		rc, sfd = -1;
+	int		rc = 0;
+	int		sfd = -1;
 	uint64_t	offset = 0;
 	uint64_t	checkpointed_io_seq;
 	zvol_info_t	*zinfo = NULL;
@@ -278,14 +277,13 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 	replica_ip.sin_addr.s_addr = inet_addr(rebuild_args->ip);
 	replica_ip.sin_port = htons(rebuild_args->port);
 
-	if (connect(sfd, (struct sockaddr *)&replica_ip,
-	    sizeof (replica_ip)) != 0) {
+	if ((rc = connect(sfd, (struct sockaddr *)&replica_ip,
+	    sizeof (replica_ip))) != 0) {
 		perror("connect");
 		goto exit;
 	}
 
 	/* Set state in-progess state now */
-	uzfs_zvol_set_rebuild_status(zinfo->zv, ZVOL_REBUILDING_IN_PROGRESS);
 	uzfs_zvol_get_last_committed_io_no(zinfo->zv, &checkpointed_io_seq);
 	zvol_state = zinfo->zv;
 	bzero(&hdr, sizeof (hdr));
@@ -308,6 +306,11 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 	}
 
 next_step:
+#if 0
+	if (ZVOL_IS_REBUILDING_FAILED(zinfo->zv)) {
+		goto exit;
+	}
+#endif
 	if (offset >= ZVOL_VOLUME_SIZE(zvol_state)) {
 		hdr.opcode = ZVOL_OPCODE_REBUILD_COMPLETE;
 		rc = uzfs_zvol_socket_write(sfd, (char *)&hdr, sizeof (hdr));
@@ -315,8 +318,10 @@ next_step:
 			ZREPL_ERRLOG("Socket write failed, err: %d\n", errno);
 			goto exit;
 		}
-		atomic_dec_16(&zinfo->zv->rebuild_info.rebuild_cnt);
-		if (!zinfo->zv->rebuild_info.rebuild_cnt) {
+
+		atomic_inc_16(&zinfo->zv->rebuild_info.rebuild_done_cnt);
+		if (zinfo->zv->rebuild_info.rebuild_cnt ==
+		    zinfo->zv->rebuild_info.rebuild_done_cnt) {
 			/* Mark replica healthy now */
 			uzfs_zvol_set_rebuild_status(zinfo->zv,
 			    ZVOL_REBUILDING_DONE);
@@ -341,6 +346,11 @@ next_step:
 	}
 
 	while (1) {
+#if 0
+		if (ZVOL_IS_REBUILDING_FAILED(zinfo->zv)) {
+			goto exit;
+		}
+#endif
 		rc = uzfs_zvol_socket_read(sfd, (char *)&hdr, sizeof (hdr));
 		if (rc != 0) {
 			ZREPL_ERRLOG("Socket read failed, err: %d\n", errno);
@@ -360,7 +370,6 @@ next_step:
 		zio_cmd = zio_cmd_alloc(&hdr, sfd);
 		rc = uzfs_zvol_socket_read(sfd, zio_cmd->buf, hdr.len);
 		if (rc != 0) {
-			zio_cmd_free(&zio_cmd);
 			ZREPL_ERRLOG("Socket read failed with "
 			    "error: %d\n", errno);
 			goto exit;
@@ -383,13 +392,13 @@ exit:
 	if (sfd != -1)
 		close(sfd);
 
-	if (ZVOL_IS_DEGRADED(zinfo->zv))
-		uzfs_zvol_set_rebuild_status(zinfo->zv, ZVOL_REBUILDING_INIT);
-	/*
-	 * Parent thread have taken refcount, drop it now.
-	 */
+	if (rc == -1)
+		uzfs_zvol_set_rebuild_status(zinfo->zv, ZVOL_REBUILDING_FAILED);
+
+	ZREPL_LOG("uzfs_zvol_rebuild_dw_replica thread exiting, volume:%s\n",
+	    zinfo->name);
+	/* Parent thread have taken refcount, drop it now */
 	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 
-	printf("uzfs_zvol_rebuild_dw_replica thread exiting\n");
 	zk_thread_exit();
 }

--- a/cmd/zrepl/data_conn.c
+++ b/cmd/zrepl/data_conn.c
@@ -306,11 +306,11 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 	}
 
 next_step:
-#if 0
+
 	if (ZVOL_IS_REBUILDING_FAILED(zinfo->zv)) {
 		goto exit;
 	}
-#endif
+
 	if (offset >= ZVOL_VOLUME_SIZE(zvol_state)) {
 		hdr.opcode = ZVOL_OPCODE_REBUILD_COMPLETE;
 		rc = uzfs_zvol_socket_write(sfd, (char *)&hdr, sizeof (hdr));
@@ -346,11 +346,11 @@ next_step:
 	}
 
 	while (1) {
-#if 0
+
 		if (ZVOL_IS_REBUILDING_FAILED(zinfo->zv)) {
 			goto exit;
 		}
-#endif
+
 		rc = uzfs_zvol_socket_read(sfd, (char *)&hdr, sizeof (hdr));
 		if (rc != 0) {
 			ZREPL_ERRLOG("Socket read failed, err: %d\n", errno);

--- a/cmd/zrepl/mgmt_conn.c
+++ b/cmd/zrepl/mgmt_conn.c
@@ -597,8 +597,8 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		io_sfd = create_and_bind("", B_FALSE, B_FALSE);
 		if (io_sfd < 0) {
 			/* Fail this rebuild process entirely */
-			ZREPL_ERRLOG("Rebuild IO socket create and bind "
-			    "failed on Volume:%s\n", zinfo->name);
+			fprintf(stderr, "Rebuild IO socket create and bind"
+			    " failed on volume: %s\n", zinfo->name);
 			uzfs_zvol_set_rebuild_status(zinfo->zv,
 			    ZVOL_REBUILDING_FAILED);
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);

--- a/cmd/zrepl/mgmt_conn.c
+++ b/cmd/zrepl/mgmt_conn.c
@@ -577,6 +577,7 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 			 */
 			if ((strcmp(mack->volname, "")) == 0) {
 				zinfo->zv->rebuild_info.rebuild_cnt = 0;
+				zinfo->zv->rebuild_info.rebuild_done_cnt = 0;
 				/* Mark replica healthy now */
 				uzfs_zvol_set_rebuild_status(zinfo->zv,
 				    ZVOL_REBUILDING_DONE);
@@ -587,20 +588,28 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 				uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 				break;
 			}
+			uzfs_zvol_set_rebuild_status(zinfo->zv,
+			    ZVOL_REBUILDING_IN_PROGRESS);
 		} else {
 			uzfs_zinfo_take_refcnt(zinfo, B_FALSE);
 		}
 
 		io_sfd = create_and_bind("", B_FALSE, B_FALSE);
 		if (io_sfd < 0) {
-			printf("Rebuild IO socket create and bind failed\n");
+			/* Fail this rebuild process entirely */
+			ZREPL_ERRLOG("Rebuild IO socket create and bind "
+			    "failed on Volume:%s\n", zinfo->name);
+			uzfs_zvol_set_rebuild_status(zinfo->zv,
+			    ZVOL_REBUILDING_FAILED);
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
-			continue;
+			break;
 		}
 
 		thrd_arg = kmem_alloc(sizeof (rebuild_thread_arg_t), KM_SLEEP);
 		thrd_arg->zinfo = zinfo;
 		thrd_arg->fd = io_sfd;
+		thrd_arg->port = mack->port;
+		strlcpy(thrd_arg->ip, mack->ip, MAX_IP_LEN);
 		strlcpy(thrd_arg->zvol_name, mack->volname, MAXNAMELEN);
 		thrd_info = zk_thread_create(NULL, 0,
 		    uzfs_zvol_rebuild_dw_replica, thrd_arg, 0, NULL, TS_RUN, 0,

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -349,6 +349,9 @@ read_socket:
 				kmem_free(name, hdr.len);
 				goto exit;
 			}
+
+			ZREPL_ERRLOG("Rebuild scanner started on volume:%s\n",
+			    name);
 			kmem_free(name, hdr.len);
 			warg.zinfo = zinfo;
 			warg.fd = fd;
@@ -370,7 +373,8 @@ read_socket:
 			    uzfs_zvol_rebuild_scanner_callback,
 			    rebuild_req_offset, rebuild_req_len, &warg);
 			if (rc != 0) {
-				printf("Rebuild scanning failed\n");
+				ZREPL_ERRLOG("Rebuild scanning failed on "
+				    "Volume:%s\n", zinfo->name);
 			}
 			bzero(&hdr, sizeof (hdr));
 			hdr.status = ZVOL_OP_STATUS_OK;

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -716,8 +716,12 @@ uzfs_zvol_io_ack_sender(void *arg)
 		    (char *)&zio_cmd->hdr, sizeof (zio_cmd->hdr));
 		if (rc == -1) {
 			ZREPL_ERRLOG("socket write err :%d\n", errno);
+			if (zio_cmd->conn == fd) {
+				zio_cmd_free(&zio_cmd);
+				goto exit;
+			}
 			zio_cmd_free(&zio_cmd);
-			goto exit;
+			continue;
 		}
 
 		switch (zio_cmd->hdr.opcode) {
@@ -734,7 +738,8 @@ uzfs_zvol_io_ack_sender(void *arg)
 				if (rc == -1) {
 					ZREPL_ERRLOG("socket write err :%d\n",
 					    errno);
-					goto exit;
+					if (zio_cmd->conn == fd)
+						goto exit;
 				}
 				zinfo->read_req_ack_cnt++;
 				break;

--- a/include/sys/uzfs_zvol.h
+++ b/include/sys/uzfs_zvol.h
@@ -56,6 +56,7 @@ typedef struct zvol_rebuild_info {
 	zvol_rebuild_status_t zv_rebuild_status; /* zvol rebuilding status */
 	uint64_t rebuild_bytes;
 	uint16_t rebuild_cnt;
+	uint16_t rebuild_done_cnt;
 } zvol_rebuild_info_t;
 
 /*
@@ -94,6 +95,8 @@ typedef struct zvol_state zvol_state_t;
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_IN_PROGRESS)
 #define	ZVOL_IS_REBUILDED(zv)	\
 	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_DONE)
+#define	ZVOL_IS_REBUILDING_FAILED(zv)	\
+	(zv->rebuild_info.zv_rebuild_status == ZVOL_REBUILDING_FAILED)
 
 extern int zvol_get_data(void *arg, lr_write_t *lr, char *buf, zio_t *zio);
 

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -61,13 +61,19 @@ typedef struct zvol_info_s {
 	zvol_state_t	*zv;
 	int 		refcnt;
 	int		is_io_ack_sender_created;
+	uint64_t	running_io_seq;
 	uint64_t	checkpointed_io_seq;
 	taskq_t		*uzfs_zvol_taskq;	/* Taskq for minor management */
 
 	/* Thread sync related */
 
-	/* For protection of complete_queue */
+	/*
+	 * For protection of:
+	 * 1. is_io_ack_sender_created
+	 * 2. running_io_seq
+	 */
 	pthread_mutex_t	zinfo_mutex;
+	/* For protection of complete_queue */
 	pthread_mutex_t	complete_queue_mutex;
 	pthread_cond_t	io_ack_cond;
 

--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -119,7 +119,8 @@ typedef struct mgmt_ack mgmt_ack_t;
 enum zvol_rebuild_status {
 	ZVOL_REBUILDING_INIT,		/* rebuilding initiated on zvol */
 	ZVOL_REBUILDING_IN_PROGRESS,	/* zvol is rebuilding */
-	ZVOL_REBUILDING_DONE		/* done with rebuilding */
+	ZVOL_REBUILDING_DONE,		/* done with rebuilding */
+	ZVOL_REBUILDING_FAILED		/* Rebuilding failed */
 } __attribute__((packed));
 
 typedef enum zvol_rebuild_status zvol_rebuild_status_t;

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -316,6 +316,9 @@ uzfs_zinfo_update_io_seq_for_all_volumes(void)
 		if (uzfs_zvol_get_status(zinfo->zv) == ZVOL_STATUS_HEALTHY) {
 			uzfs_zvol_store_last_committed_io_no(zinfo->zv,
 			    zinfo->checkpointed_io_seq);
+			(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
+			zinfo->checkpointed_io_seq = zinfo->running_io_seq;
+			(void) pthread_mutex_unlock(&zinfo->zinfo_mutex);
 		}
 	}
 	(void) mutex_exit(&zvol_list_mutex);

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -35,6 +35,8 @@ VOLSIZE="1G"
 UZFS_TEST_POOL="testp"
 UZFS_TEST_VOL="ds0"
 UZFS_REBUILD_VOL="ds1"
+UZFS_REBUILD_VOL1="ds2"
+UZFS_REBUILD_VOL2="ds3"
 UZFS_TEST_VOLSIZE="128M"
 UZFS_TEST_VOLSIZE_IN_NUM=134217728
 ZREPL_PID="-1"
@@ -861,6 +863,14 @@ run_zrepl_rebuild_uzfs_test()
 	log_must $ZFS create -V $UZFS_TEST_VOLSIZE \
 	    $UZFS_TEST_POOL/$UZFS_REBUILD_VOL -b $2
 	log_must $ZFS set sync=$3 $UZFS_TEST_POOL/$UZFS_REBUILD_VOL
+	
+	log_must $ZFS create -V $UZFS_TEST_VOLSIZE \
+	    $UZFS_TEST_POOL/$UZFS_REBUILD_VOL1 -b $2
+	log_must $ZFS set sync=$3 $UZFS_TEST_POOL/$UZFS_REBUILD_VOL1
+
+	log_must $ZFS create -V $UZFS_TEST_VOLSIZE \
+	    $UZFS_TEST_POOL/$UZFS_REBUILD_VOL2 -b $2
+	log_must $ZFS set sync=$3 $UZFS_TEST_POOL/$UZFS_REBUILD_VOL2
 
 	log_must $UZFS_TEST -T 7
 	sleep 20


### PR DESCRIPTION
Signed-off-by: satbir <satbir.chhikara@gmail.com>

This change is related to handing rebuild failure. During mesh rebuild more than one replica will be used for rebuilding a replica i.e. multiple rebuild operation will run in parallel (N x 1). Before a replia marked healthy,
it should go through one round of rebuild with N replicas where is N is consistency factor. So this change is to not mark replica healthy if one of operation failed due to any reason.

For more info on it, please refer design doc(Design doc link is given below).

https://docs.google.com/document/d/1GBx5hrCw0-88Zw1FD5LoBbGSP4jP6kUU3qAgCMinoNM/edit?usp=sharing

List of unit tests automated:-
Unit Testing Plan
Test case 1: When there is one replica in system
When only one replica is used in system, iSCSI controller should be able to rebuild this replica to make it healthy because there is no other replica to rebuild from.

Test case 2: When there is N(N >= 3) replicas and one replica need to be rebuilt
When there are N replicas where N > 3, system is up for a while all replicas were healthy, then one replica crashed/network failed, when this particular replica come back and try to register to iSCSI controller, it should be in downgraded state. iSCSI controller should be able to trigger rebuild process on this replica with the help of  another healthy replica in the replication group. This test case is same as adding a new replica in replication group after few days of system up.

Test case 3: When there is N(N >= 3) replicas and all need to be rebuilt
In this scenario, all replicas come online and trying to register to iSCSI controller, all replicas are in downgraded mode. iSCSI controller need to start rebuild process on each one of them one by one to make them healthy. The very first rebuild process in this scenario would be a mesh rebuild. Once that replica become healthy all other rebuild should happen from this healthy replica. We can assume this test case as iSCSI controller crashed and came back online.

Test case 4: In test case 3, mesh rebuild is going on, one of the rebuild failed
Test case 3 but when mesh rebuild was going on, one of rebuild operation failed, in such situation, all other rebuild operation on this particular replica should be stopped as we can not claim this replica healthy without finishing mesh rebuild successfully. iSCSI controller should be able to restart rebuild on this replica by looking into operation status (failed) of this replica.

Test case 5: Test case 2 + new IOs coming to downgraded replica parallel to rebuild operation where new writes are probably on the same offset rebuild was also trying to write missing data.
In this test case, we are trying to see if there is any data corruption because of rebuild and new writes writing to same offset. In this case, rebuild IOs should be discarded as new writes has higher IO_seq number in metadata file.
