### PR TITLE
DE24 deadlock in ztest when calling spa fini

### DIFF
--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -36,7 +36,7 @@
 #define	SPEC_MAXOFFSET_T	((1LL << ((NBBY * sizeof (daddr32_t)) + \
 				DEV_BSHIFT - 1)) - 1)
 
-extern void zvol_create_minors(spa_t *spa, const char *name, boolean_t async);
+extern void zvol_create_minors(spa_t *spa, const char *name);
 extern void zvol_remove_minors(spa_t *spa, const char *name, boolean_t async);
 extern void zvol_rename_minors(spa_t *spa, const char *oldname,
     const char *newname, boolean_t async);

--- a/include/uzfs_mgmt.h
+++ b/include/uzfs_mgmt.h
@@ -37,8 +37,7 @@ extern int uzfs_zvol_create_meta(objset_t *os, uint64_t block_size,
     uint64_t meta_block_size, dmu_tx_t *tx);
 extern int uzfs_open_dataset(spa_t *spa, const char *ds, zvol_state_t **zv);
 extern int uzfs_zvol_create_cb(const char *ds_name, void *n);
-extern void uzfs_zvol_create_minors(spa_t *spa, const char *name,
-    boolean_t async);
+extern void uzfs_zvol_create_minors(spa_t *spa, const char *name);
 extern int uzfs_zvol_destroy_cb(const char *ds_name, void *n);
 extern uint64_t uzfs_synced_txg(zvol_state_t *zv);
 extern void uzfs_close_dataset(zvol_state_t *zv);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1699,7 +1699,7 @@ __spl_pf_fstrans_check(void)
 }
 
 void
-zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
+zvol_create_minors(spa_t *spa, const char *name)
 {
 }
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1009,7 +1009,7 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 	}
 
 	spa_history_log_internal_ds(ds, "create", tx, "");
-	zvol_create_minors(dp->dp_spa, doca->doca_name, B_TRUE);
+	zvol_create_minors(dp->dp_spa, doca->doca_name);
 
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dir_rele(pdd, FTAG);
@@ -1107,7 +1107,7 @@ dmu_objset_clone_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_name(origin, namebuf);
 	spa_history_log_internal_ds(ds, "clone", tx,
 	    "origin=%s (%llu)", namebuf, origin->ds_object);
-	zvol_create_minors(dp->dp_spa, doca->doca_clone, B_TRUE);
+	zvol_create_minors(dp->dp_spa, doca->doca_clone);
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dataset_rele(origin, FTAG);
 	dsl_dir_rele(pdd, FTAG);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -3450,7 +3450,7 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		drc->drc_newsnapobj =
 		    dsl_dataset_phys(drc->drc_ds)->ds_prev_snap_obj;
 	}
-	zvol_create_minors(dp->dp_spa, drc->drc_tofs, B_TRUE);
+	zvol_create_minors(dp->dp_spa, drc->drc_tofs);
 	/*
 	 * Release the hold from dmu_recv_begin.  This must be done before
 	 * we return to open context, so that when we free the dataset's dnode,

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1472,7 +1472,7 @@ dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 			dsl_props_set_sync_impl(ds->ds_prev,
 			    ZPROP_SRC_LOCAL, ddsa->ddsa_props, tx);
 		}
-		zvol_create_minors(dp->dp_spa, nvpair_name(pair), B_TRUE);
+		zvol_create_minors(dp->dp_spa, nvpair_name(pair));
 		dsl_dataset_rele(ds, FTAG);
 	}
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3508,7 +3508,7 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 
 	if (firstopen) {
 #ifdef _KERNEL
-		zvol_create_minors(spa, spa_name(spa), B_TRUE);
+		zvol_create_minors(spa, spa_name(spa));
 #endif
 	}
 	*spapp = spa;
@@ -4423,9 +4423,9 @@ spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_POOL_IMPORT);
 
 #ifdef _KERNEL
-	zvol_create_minors(spa, pool, B_TRUE);
+	zvol_create_minors(spa, pool);
 #else
-	uzfs_zvol_create_minors(spa, pool, B_TRUE);
+	uzfs_zvol_create_minors(spa, pool);
 #endif
 	mutex_exit(&spa_namespace_lock);
 

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -2709,7 +2709,7 @@ zvol_set_volmode(const char *ddname, zprop_source_t source, uint64_t volmode)
 }
 
 void
-zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
+zvol_create_minors(spa_t *spa, const char *name)
 {
 	zvol_task_t *task;
 	taskqid_t id;
@@ -2719,7 +2719,7 @@ zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
 		return;
 
 	id = taskq_dispatch(spa->spa_zvol_taskq, zvol_task_cb, task, TQ_SLEEP);
-	if ((async == B_FALSE) && (id != TASKQID_INVALID))
+	if (id != TASKQID_INVALID)
 		taskq_wait_id(spa->spa_zvol_taskq, id);
 }
 


### PR DESCRIPTION
There is a implementation detail in spa_open_common:

```
        /*
         * As disgusting as this is, we need to support recursive calls to this
         * function because dsl_dir_open() is called during spa_load(), and ends
         * up calling spa_open() again.  The real fix is to figure out how to
         * avoid dsl_dir_open() calling this in the first place.
         */
        if (mutex_owner(&spa_namespace_lock) != curthread) {
                mutex_enter(&spa_namespace_lock);
                locked = B_TRUE;
        }
```
which means that spa_open_common may be called recursively and in that case we don't try to grab namespace lock again which would lead to deadlock. When pool is imported and uzfs initialized, uzfs code holds uzfs dataset which calls spa_open() in turn and ends up acquiring namespace lock as above. It would not make any harm if this hold dataset code wasn't executed on behalf of asynchronous thread spawned from a zvol taskq. Hence the code above does not have a way of detecting that this is recursive call and mutex should not be taken. I have simplified the code to bare minimum - removing taskq and executing all zvol minor initialization code on behalf of a single thread. I ran ztest 4x in row and no deadlock.

This is the stack of the stuck thread:
```
Thread 48 (Thread 0x7f15e67a3700 (LWP 989)):
#0  __lll_lock_wait () at ../sysdeps/unix/sysv/linux/x86_64/lowlevellock.S:135
#1  0x00007f15e9d1cf0d in __GI___pthread_mutex_lock (mutex=0x55ad9ef49850 <spa_namespace_lock+16>) at ../nptl/pthread_mutex_lock.c:80
#2  0x00007f15ea4e1751 in mutex_enter (mp=0x55ad9ef49840 <spa_namespace_lock>) at kernel.c:477
#3  0x00007f15ea5b7c0e in spa_open_common (pool=0x7f15a8068480 "ztest/ds_5", spapp=0x7f15e67a1ab8, tag=0x7f15a8067360, nvpolicy=0x0, config=0x0)
    at ../../module/zfs/spa.c:3419
#4  0x00007f15ea5b8041 in spa_open (name=0x7f15a8068480 "ztest/ds_5", spapp=0x7f15e67a1ab8, tag=0x7f15a8067360) at ../../module/zfs/spa.c:3529
#5  0x00007f15ea4e9b03 in uzfs_own_dataset (ds_name=0x7f15a8068480 "ztest/ds_5", z=0x7f15e67a1b50) at uzfs_mgmt.c:324
#6  0x00007f15ea4ea151 in uzfs_zvol_create_cb (ds_name=0x7f15a8068480 "ztest/ds_5", arg=0x0) at uzfs_mgmt.c:474
#7  0x00007f15ea53c75a in dmu_objset_find_impl (spa=0x55ada0f414b0, name=0x7f15a8068480 "ztest/ds_5", func=0x7f15ea4ea0bf <uzfs_zvol_create_cb>, arg=0x0,
    flags=2) at ../../module/zfs/dmu_objset.c:2421
#8  0x00007f15ea53c3cf in dmu_objset_find_impl (spa=0x55ada0f414b0, name=0x55ada1030720 "ztest", func=0x7f15ea4ea0bf <uzfs_zvol_create_cb>, arg=0x0, flags=2)
    at ../../module/zfs/dmu_objset.c:2364
#9  0x00007f15ea53c7ed in dmu_objset_find (name=0x55ada1030720 "ztest", func=0x7f15ea4ea0bf <uzfs_zvol_create_cb>, arg=0x0, flags=2)
    at ../../module/zfs/dmu_objset.c:2437
#10 0x00007f15ea4ea2ae in uzfs_zvol_create_minors_impl (n=0x55ada1030720) at uzfs_mgmt.c:512
#11 0x00007f15ea4e61cc in taskq_thread (arg=0x55ada1289d30) at taskq.c:243
#12 0x00007f15ea4e02ea in zk_thread_helper (arg=0x55ada1185c10) at kernel.c:145
#13 0x00007f15e9d1a6da in start_thread (arg=0x7f15e67a3700) at pthread_create.c:456
#14 0x00007f15e9a54d7f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:105
```
and here is the thread which seems to hold spa_namespace_lock:
```
Thread 1 (Thread 0x7f15eb1c97c0 (LWP 32283)):
#0  pthread_cond_wait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_wait.S:185
#1  0x00007f15ea4e2b34 in cv_wait (cv=0x55ada0f41850, mp=0x55ada0f417f8) at kernel.c:652
#2  0x00007f15ea5cb3e3 in spa_evicting_os_wait (spa=0x55ada0f414b0) at ../../module/zfs/spa_misc.c:1746
#3  0x00007f15ea5b1c6b in spa_deactivate (spa=0x55ada0f414b0) at ../../module/zfs/spa.c:1207
#4  0x00007f15ea5c30a8 in spa_evict_all () at ../../module/zfs/spa.c:7103
#5  0x00007f15ea5cba2c in spa_fini () at ../../module/zfs/spa_misc.c:1911
#6  0x00007f15ea4e4f87 in kernel_fini () at kernel.c:1542
#7  0x000055ad9ed3e2ea in ztest_run (zs=0x7f15eb1fc4a0) at ztest.c:6498
#8  0x000055ad9ed400cd in main (argc=1, argv=0x7ffd108372f8) at ztest.c:6994
```
There is no other thread which would seem to be involved in this deadlock. So create_minors is waiting for spa_fini. But what spa_fini (in spa_evicting_os_wait) is waiting for? Somehow it seems to be blocked by the create_minors thread in turn. Likely there is a reasonable explanation. Nevertheless the fix is still sound as if create_minors is executed synchronously from spa_import, then it cannot happen that it would have a need to acquire the namespace lock because it is already held by the thread.