### PR TITLE
US1532 Snapshot feature related User Story wrt cStor replica

### DIFF
--- a/include/zrepl_prot.h
+++ b/include/zrepl_prot.h
@@ -69,7 +69,7 @@ enum zvol_op_code {
 	ZVOL_OPCODE_REBUILD_STEP_DONE,
 	ZVOL_OPCODE_REBUILD_COMPLETE,
 	ZVOL_OPCODE_SNAP_CREATE,
-	ZVOL_OPCODE_SNAP_ROLLBACK,
+	ZVOL_OPCODE_SNAP_DESTROY,
 } __attribute__((packed));
 
 typedef enum zvol_op_code zvol_op_code_t;


### PR DESCRIPTION
New snapshot create and destroy commands on management connection. There is a supporting code for executing these functions asynchronously using zinfo->uzfs_zvol_taskq taskq, so that the main event loop is not blocked while these actions are performed.