### PR TITLE
DE24 deadlock in ztest when calling spa fini (2nd version of the fix)

### DIFF
--- a/include/sys/zvol.h
+++ b/include/sys/zvol.h
@@ -36,7 +36,7 @@
 #define	SPEC_MAXOFFSET_T	((1LL << ((NBBY * sizeof (daddr32_t)) + \
 				DEV_BSHIFT - 1)) - 1)
 
-extern void zvol_create_minors(spa_t *spa, const char *name);
+extern void zvol_create_minors(spa_t *spa, const char *name, boolean_t async);
 extern void zvol_remove_minors(spa_t *spa, const char *name, boolean_t async);
 extern void zvol_rename_minors(spa_t *spa, const char *oldname,
     const char *newname, boolean_t async);

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1699,7 +1699,7 @@ __spl_pf_fstrans_check(void)
 }
 
 void
-zvol_create_minors(spa_t *spa, const char *name)
+zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
 {
 }
 

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -1009,7 +1009,7 @@ dmu_objset_create_sync(void *arg, dmu_tx_t *tx)
 	}
 
 	spa_history_log_internal_ds(ds, "create", tx, "");
-	zvol_create_minors(dp->dp_spa, doca->doca_name);
+	zvol_create_minors(dp->dp_spa, doca->doca_name, B_TRUE);
 
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dir_rele(pdd, FTAG);
@@ -1107,7 +1107,7 @@ dmu_objset_clone_sync(void *arg, dmu_tx_t *tx)
 	dsl_dataset_name(origin, namebuf);
 	spa_history_log_internal_ds(ds, "clone", tx,
 	    "origin=%s (%llu)", namebuf, origin->ds_object);
-	zvol_create_minors(dp->dp_spa, doca->doca_clone);
+	zvol_create_minors(dp->dp_spa, doca->doca_clone, B_TRUE);
 	dsl_dataset_rele(ds, FTAG);
 	dsl_dataset_rele(origin, FTAG);
 	dsl_dir_rele(pdd, FTAG);

--- a/module/zfs/dmu_send.c
+++ b/module/zfs/dmu_send.c
@@ -3450,7 +3450,7 @@ dmu_recv_end_sync(void *arg, dmu_tx_t *tx)
 		drc->drc_newsnapobj =
 		    dsl_dataset_phys(drc->drc_ds)->ds_prev_snap_obj;
 	}
-	zvol_create_minors(dp->dp_spa, drc->drc_tofs);
+	zvol_create_minors(dp->dp_spa, drc->drc_tofs, B_TRUE);
 	/*
 	 * Release the hold from dmu_recv_begin.  This must be done before
 	 * we return to open context, so that when we free the dataset's dnode,

--- a/module/zfs/dsl_dataset.c
+++ b/module/zfs/dsl_dataset.c
@@ -1472,7 +1472,7 @@ dsl_dataset_snapshot_sync(void *arg, dmu_tx_t *tx)
 			dsl_props_set_sync_impl(ds->ds_prev,
 			    ZPROP_SRC_LOCAL, ddsa->ddsa_props, tx);
 		}
-		zvol_create_minors(dp->dp_spa, nvpair_name(pair));
+		zvol_create_minors(dp->dp_spa, nvpair_name(pair), B_TRUE);
 		dsl_dataset_rele(ds, FTAG);
 	}
 }

--- a/module/zfs/spa.c
+++ b/module/zfs/spa.c
@@ -3508,7 +3508,7 @@ spa_open_common(const char *pool, spa_t **spapp, void *tag, nvlist_t *nvpolicy,
 
 	if (firstopen) {
 #ifdef _KERNEL
-		zvol_create_minors(spa, spa_name(spa));
+		zvol_create_minors(spa, spa_name(spa), B_TRUE);
 #endif
 	}
 	*spapp = spa;
@@ -4423,7 +4423,7 @@ spa_import(char *pool, nvlist_t *config, nvlist_t *props, uint64_t flags)
 	spa_event_notify(spa, NULL, NULL, ESC_ZFS_POOL_IMPORT);
 
 #ifdef _KERNEL
-	zvol_create_minors(spa, pool);
+	zvol_create_minors(spa, pool, B_TRUE);
 #else
 	uzfs_zvol_create_minors(spa, pool);
 #endif

--- a/module/zfs/zvol.c
+++ b/module/zfs/zvol.c
@@ -2709,7 +2709,7 @@ zvol_set_volmode(const char *ddname, zprop_source_t source, uint64_t volmode)
 }
 
 void
-zvol_create_minors(spa_t *spa, const char *name)
+zvol_create_minors(spa_t *spa, const char *name, boolean_t async)
 {
 	zvol_task_t *task;
 	taskqid_t id;
@@ -2719,7 +2719,7 @@ zvol_create_minors(spa_t *spa, const char *name)
 		return;
 
 	id = taskq_dispatch(spa->spa_zvol_taskq, zvol_task_cb, task, TQ_SLEEP);
-	if (id != TASKQID_INVALID)
+	if ((async == B_FALSE) && (id != TASKQID_INVALID))
 		taskq_wait_id(spa->spa_zvol_taskq, id);
 }
 


### PR DESCRIPTION
Less intrusive version of the fix which undos most of the changes from previous commit. We don't need to change async behaviour of zvol_create_minors because that's a kernel code. So we focus just on uzfs_zvol_create_minors, which is the problem. I cannot preserve the taskq and async behaviour there because we need to execute uzfs zvol callback on behalf of the same thread which does zpool import.