### PR TITLE
 TA435 Dockerize repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+#
+# This Dockerfile builds a recent base image containing cstor binaries and 
+# libraries.
+#
+
+FROM ubuntu:16.04
+
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \ 
+    apt-get update && \
+    apt-get install -y apt-utils libaio1 libjemalloc1
+
+COPY cmd/zrepl/.libs/zrepl /usr/local/bin/
+COPY cmd/zpool/.libs/zpool /usr/local/bin/
+COPY cmd/zfs/.libs/zfs /usr/local/bin/
+
+COPY lib/libzpool/.libs/*.so* /usr/lib/
+COPY lib/libuutil/.libs/*.so* /usr/lib/
+COPY lib/libnvpair/.libs/*.so* /usr/lib/
+COPY lib/libzfs/.libs/*.so* /usr/lib/
+COPY lib/libzfs_core/.libs/*.so* /usr/lib/
+
+ARG BUILD_DATE
+LABEL org.label-schema.name="cstor"
+LABEL org.label-schema.description="OpenEBS cstor"
+LABEL org.label-schema.url="http://www.openebs.io/"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.build-date=$BUILD_DATE
+
+ENTRYPOINT ["/usr/local/bin/zrepl"]
+EXPOSE 7676


### PR DESCRIPTION
I find it needlessly complicated to build docker uzfs images using a different repo than the repo with uzfs sources. If nothing else, it makes developer lives easier in case they want to test their modifications using containers. Ideally we should leverage Dockerfile from zfs repo for releases as well, however external dependencies might not allow it.