### PR TITLE
US1541 Debugging and logging at cStor target

### DIFF
--- a/cmd/zrepl/Makefile.am
+++ b/cmd/zrepl/Makefile.am
@@ -2,8 +2,7 @@ include $(top_srcdir)/config/Rules.am
 
 # -Wnoformat-truncation to get rid of compiler warning for unchecked
 #  truncating snprintfs on gcc 7.1.1.
-AM_CFLAGS += $(DEBUG_STACKFLAGS) $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION)
-AM_CPPFLAGS += -DDEBUG
+AM_CFLAGS += $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION)
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \

--- a/cmd/zrepl/data_conn.c
+++ b/cmd/zrepl/data_conn.c
@@ -120,7 +120,11 @@ uzfs_zvol_socket_write(int fd, char *buf, uint64_t nbytes)
 	while (nbytes) {
 		count = write(fd, (void *)p, nbytes);
 		if (count <= 0) {
-			LOG_ERRNO("Write error");
+			if (count == 0) {
+				LOG_INFO("Connection closed");
+			} else {
+				LOG_ERRNO("Socket write error");
+			}
 			return (-1);
 		}
 		p += count;

--- a/cmd/zrepl/data_conn.c
+++ b/cmd/zrepl/data_conn.c
@@ -99,7 +99,11 @@ uzfs_zvol_socket_read(int fd, char *buf, uint64_t nbytes)
 	while (nbytes) {
 		count = read(fd, (void *)p, nbytes);
 		if (count <= 0) {
-			ZREPL_ERRLOG("Read error:%d\n", errno);
+			if (count == 0) {
+				LOG_INFO("Connection closed");
+			} else {
+				LOG_ERRNO("Socket read error");
+			}
 			return (-1);
 		}
 		p += count;
@@ -116,7 +120,7 @@ uzfs_zvol_socket_write(int fd, char *buf, uint64_t nbytes)
 	while (nbytes) {
 		count = write(fd, (void *)p, nbytes);
 		if (count <= 0) {
-			ZREPL_ERRLOG("Write error:%d\n", errno);
+			LOG_ERRNO("Write error");
 			return (-1);
 		}
 		p += count;
@@ -233,8 +237,7 @@ uzfs_zvol_worker(void *arg)
 	}
 
 	if (rc != 0) {
-		ZREPL_ERRLOG("Zvol op_code :%d failed with "
-		    "error: %d\n", hdr->opcode, errno);
+		LOG_ERR("OP code %d failed", hdr->opcode);
 		hdr->status = ZVOL_OP_STATUS_FAILED;
 		hdr->len = 0;
 	} else {
@@ -311,14 +314,14 @@ uzfs_zvol_rebuild_dw_replica(void *arg)
 
 	rc = uzfs_zvol_socket_write(sfd, (char *)&hdr, sizeof (hdr));
 	if (rc == -1) {
-		ZREPL_ERRLOG("Socket write failed, err: %d\n", errno);
+		LOG_ERRNO("Socket write failed");
 		goto exit;
 	}
 
 	rc = uzfs_zvol_socket_write(sfd, (void *)rebuild_args->zvol_name,
 	    hdr.len);
 	if (rc == -1) {
-		ZREPL_ERRLOG("Socket write failed, err: %d\n", errno);
+		LOG_ERRNO("Socket write failed");
 		goto exit;
 	}
 
@@ -332,7 +335,7 @@ next_step:
 		hdr.opcode = ZVOL_OPCODE_REBUILD_COMPLETE;
 		rc = uzfs_zvol_socket_write(sfd, (char *)&hdr, sizeof (hdr));
 		if (rc != 0) {
-			ZREPL_ERRLOG("Socket write failed, err: %d\n", errno);
+			LOG_ERRNO("Socket write failed");
 			goto exit;
 		}
 
@@ -345,8 +348,7 @@ next_step:
 			uzfs_zvol_set_status(zinfo->zv, ZVOL_STATUS_HEALTHY);
 			uzfs_update_ionum_interval(zinfo, 0);
 		}
-		ZREPL_ERRLOG("Rebuilding on Replica:%s completed\n",
-		    zinfo->name);
+		LOG_INFO("Rebuilding zvol %s completed", zinfo->name);
 		goto exit;
 	} else {
 		bzero(&hdr, sizeof (hdr));
@@ -358,7 +360,7 @@ next_step:
 		hdr.len = ZVOL_REBUILD_STEP_SIZE;
 		rc = uzfs_zvol_socket_write(sfd, (char *)&hdr, sizeof (hdr));
 		if (rc != 0) {
-			ZREPL_ERRLOG("Socket write failed, err: %d\n", errno);
+			LOG_ERRNO("Socket write failed");
 			goto exit;
 		}
 	}
@@ -371,13 +373,13 @@ next_step:
 
 		rc = uzfs_zvol_socket_read(sfd, (char *)&hdr, sizeof (hdr));
 		if (rc != 0) {
-			ZREPL_ERRLOG("Socket read failed, err: %d\n", errno);
+			LOG_ERRNO("Socket read failed");
 			goto exit;
 		}
 
 		if (hdr.opcode == ZVOL_OPCODE_REBUILD_STEP_DONE) {
 			offset += ZVOL_REBUILD_STEP_SIZE;
-			printf("ZVOL_OPCODE_REBUILD_STEP_DONE received\n");
+			LOG_DEBUG("ZVOL_OPCODE_REBUILD_STEP_DONE received");
 			goto next_step;
 		}
 
@@ -388,8 +390,7 @@ next_step:
 		zio_cmd = zio_cmd_alloc(&hdr, sfd);
 		rc = uzfs_zvol_socket_read(sfd, zio_cmd->buf, hdr.len);
 		if (rc != 0) {
-			ZREPL_ERRLOG("Socket read failed with "
-			    "error: %d\n", errno);
+			LOG_ERRNO("Socket read failed");
 			goto exit;
 		}
 
@@ -413,7 +414,7 @@ exit:
 	if (rc == -1)
 		uzfs_zvol_set_rebuild_status(zinfo->zv, ZVOL_REBUILDING_FAILED);
 
-	ZREPL_LOG("uzfs_zvol_rebuild_dw_replica thread exiting, volume:%s\n",
+	LOG_DEBUG("uzfs_zvol_rebuild_dw_replica thread exiting, zvol: %s",
 	    zinfo->name);
 	/* Parent thread have taken refcount, drop it now */
 	uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
@@ -443,8 +444,8 @@ uzfs_zvol_timer_thread(void)
 				next_check = zinfo->checkpointed_time +
 				    zinfo->update_ionum_interval;
 				if (next_check <= now) {
-					fprintf(stderr, "Checkpointing ionum "
-					    "%lu on %s\n",
+					LOG_DEBUG("Checkpointing ionum "
+					    "%lu on %s",
 					    zinfo->checkpointed_ionum,
 					    zinfo->name);
 					uzfs_zvol_store_last_committed_io_no(

--- a/cmd/zrepl/mgmt_conn.c
+++ b/cmd/zrepl/mgmt_conn.c
@@ -140,7 +140,8 @@ close_conn(uzfs_mgmt_conn_t *conn)
 {
 	async_task_t *async_task;
 
-	DBGCONN(conn, "Closing the connection");
+	if (conn->conn_state != CS_CONNECT)
+		DBGCONN(conn, "Closing the connection");
 
 	/* Release resources tight to the conn */
 	if (conn->conn_buf != NULL) {

--- a/cmd/zrepl/mgmt_conn.c
+++ b/cmd/zrepl/mgmt_conn.c
@@ -63,33 +63,9 @@
  *     their state.
  */
 
-/* To print verbose debug messages uncomment the following line */
-#define	MGMT_CONN_DEBUG	1
-
-#ifdef MGMT_CONN_DEBUG
-static const char *
-gettimestamp(void)
-{
-	struct timeval tv;
-	static char buf[20];
-	struct tm *timeinfo;
-	unsigned int ms;
-
-	gettimeofday(&tv, NULL);
-	timeinfo = localtime(&tv.tv_sec);
-	ms = tv.tv_usec / 1000;
-
-	strftime(buf, sizeof (buf), "%H:%M:%S.", timeinfo);
-	snprintf(buf + 9, sizeof (buf) - 9, "%u", ms);
-
-	return (buf);
-}
-#define	DBGCONN(c, fmt, ...)	fprintf(stderr, "%s [tgt %s:%u]: " fmt "\n", \
-				gettimestamp(), \
+/* LOG_DEBUG wrapper which puts target address prefix to message */
+#define	DBGCONN(c, fmt, ...)	LOG_DEBUG("[tgt %s:%u]: " fmt, \
 				(c)->conn_host, (c)->conn_port, ##__VA_ARGS__)
-#else
-#define	DBGCONN(c, fmt, ...)
-#endif
 
 /* Max # of events from epoll processed at once */
 #define	MAX_EVENTS	10
@@ -241,7 +217,8 @@ connect_to_tgt(uzfs_mgmt_conn_t *conn)
 	/* EINPROGRESS means that EPOLLOUT will tell us when connect is done */
 	if (rc != 0 && errno != EINPROGRESS) {
 		close(sfd);
-		DBGCONN(conn, "Failed to connect");
+		LOG_ERRNO("Failed to connect to %s:%d", conn->conn_host,
+		    conn->conn_port);
 		return (-1);
 	}
 	return (sfd);
@@ -515,11 +492,11 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	mgmt_ack_t 	mgmt_ack;
 	zvol_io_hdr_t	hdr;
 
-	printf("Volume %s sent for enq\n", name);
+	LOG_INFO("Handshake on zvol %s", name);
 
 	bzero(&mgmt_ack, sizeof (mgmt_ack));
 	if (uzfs_zvol_get_ip(mgmt_ack.ip) == -1) {
-		fprintf(stderr, "Unable to get IP with err: %d\n", errno);
+		LOG_ERRNO("Unable to get IP");
 		return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED, hdrp->opcode,
 		    hdrp->io_seq));
 	}
@@ -535,8 +512,7 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	 */
 	if (zv->zv_objset == NULL) {
 		if (uzfs_hold_dataset(zv) != 0) {
-			fprintf(stderr, "Failed to hold zvol during "
-			    "handshake\n");
+			LOG_ERR("Failed to hold zvol during handshake");
 			return (reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq));
 		}
@@ -638,7 +614,8 @@ uzfs_zvol_execute_async_command(void *arg)
 	case ZVOL_OPCODE_SNAP_CREATE:
 		rc = dmu_objset_snapshot_one(zinfo->name, snapname);
 		if (rc != 0) {
-			fprintf(stderr, "Snapshot create failed: %d\n", rc);
+			LOG_ERR("Failed to create %s@%s: %d",
+			    zinfo->name, snapname, rc);
 			async_task->status = ZVOL_OP_STATUS_FAILED;
 		} else {
 			async_task->status = ZVOL_OP_STATUS_OK;
@@ -649,7 +626,8 @@ uzfs_zvol_execute_async_command(void *arg)
 		rc = dsl_destroy_snapshot(dataset, B_FALSE);
 		strfree(dataset);
 		if (rc != 0) {
-			fprintf(stderr, "Snapshot destroy failed: %d\n", rc);
+			LOG_ERR("Failed to destroy %s@%s: %d",
+			    zinfo->name, snapname, rc);
 			async_task->status = ZVOL_OP_STATUS_FAILED;
 		} else {
 			async_task->status = ZVOL_OP_STATUS_OK;
@@ -717,14 +695,14 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 
 	for (; rebuild_op_cnt > 0; rebuild_op_cnt--, mack++) {
 		if (mack->volname[0] != '\0') {
-			printf("Replica %s at %s:%u helping in rebuild\n",
+			LOG_INFO("zvol %s at %s:%u helping in rebuild",
 			    mack->volname, mack->ip, mack->port);
 		}
 		if (zinfo == NULL) {
 			zinfo = uzfs_zinfo_lookup(mack->dw_volname);
 			if ((zinfo == NULL) || (zinfo->mgmt_conn != conn)) {
-				printf("Replica %s not found or not matching "
-				    "conn\n", mack->dw_volname);
+				LOG_ERR("zvol %s not found or not matching "
+				    "connection", mack->dw_volname);
 				return (reply_nodata(conn,
 				    ZVOL_OP_STATUS_FAILED,
 				    hdrp->opcode, hdrp->io_seq));
@@ -744,7 +722,7 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 				uzfs_zvol_set_status(zinfo->zv,
 				    ZVOL_STATUS_HEALTHY);
 				uzfs_update_ionum_interval(zinfo, 0);
-				printf("Rebuild of replica %s completed\n",
+				LOG_INFO("Rebuild of zvol %s completed",
 				    zinfo->name);
 				uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
 				break;
@@ -754,8 +732,8 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		} else {
 			if (strncmp(zinfo->name, mack->dw_volname, MAXNAMELEN)
 			    != 0) {
-				printf("Replica %s not matching with zinfo"
-				    " %s\n", mack->dw_volname, zinfo->name);
+				LOG_ERR("zvol %s not matching with zinfo %s",
+				    mack->dw_volname, zinfo->name);
 				return (reply_nodata(conn,
 				    ZVOL_OP_STATUS_FAILED,
 				    hdrp->opcode, hdrp->io_seq));
@@ -766,8 +744,8 @@ uzfs_zvol_rebuild_dw_replica_start(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 		io_sfd = create_and_bind("", B_FALSE, B_FALSE);
 		if (io_sfd < 0) {
 			/* Fail this rebuild process entirely */
-			fprintf(stderr, "Rebuild IO socket create and bind"
-			    " failed on volume: %s\n", zinfo->name);
+			LOG_ERR("Rebuild IO socket create and bind"
+			    " failed on zvol: %s", zinfo->name);
 			uzfs_zvol_set_rebuild_status(zinfo->zv,
 			    ZVOL_REBUILDING_FAILED);
 			uzfs_zinfo_drop_refcnt(zinfo, B_FALSE);
@@ -823,7 +801,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 
 		if (((zinfo = uzfs_zinfo_lookup(zvol_name)) == NULL) ||
 		    (zinfo->mgmt_conn != conn)) {
-			fprintf(stderr, "Unknown zvol: %s\n", zvol_name);
+			LOG_ERR("Unknown zvol: %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
 			break;
@@ -861,7 +839,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		zvol_name[payload_size] = '\0';
 		snap = strchr(zvol_name, '@');
 		if (snap == NULL) {
-			fprintf(stderr, "Invalid snapshot name: %s\n",
+			LOG_ERR("Invalid snapshot name: %s",
 			    zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
@@ -871,7 +849,7 @@ process_message(uzfs_mgmt_conn_t *conn)
 		/* ref will be released when async command has finished */
 		if (((zinfo = uzfs_zinfo_lookup(zvol_name)) == NULL) ||
 		    (zinfo->mgmt_conn != conn)) {
-			fprintf(stderr, "Unknown zvol: %s\n", zvol_name);
+			LOG_ERR("Unknown zvol: %s", zvol_name);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_FAILED,
 			    hdrp->opcode, hdrp->io_seq);
 			break;
@@ -946,7 +924,7 @@ move_to_next_state(uzfs_mgmt_conn_t *conn)
 		kmem_free(conn->conn_buf, sizeof (uint16_t));
 		conn->conn_buf = NULL;
 		if (vers != REPLICA_VERSION) {
-			fprintf(stderr, "invalid replica protocol version %d\n",
+			LOG_ERR("Invalid replica protocol version %d",
 			    vers);
 			rc = reply_nodata(conn, ZVOL_OP_STATUS_VERSION_MISMATCH,
 			    0, 0);
@@ -1068,10 +1046,10 @@ uzfs_zvol_mgmt_thread(void *arg)
 
 			if (events[i].events & EPOLLERR) {
 				if (conn->conn_state == CS_CONNECT) {
-					DBGCONN(conn, "Failed to connect");
+					LOG_ERR("Failed to connect to %s:%d",
+					    conn->conn_host, conn->conn_port);
 				} else {
-					fprintf(stderr, "Error on connection "
-					    "to %s:%d\n",
+					LOG_ERR("Error on connection to %s:%d",
 					    conn->conn_host, conn->conn_port);
 				}
 				if (close_conn(conn) != 0)
@@ -1157,6 +1135,6 @@ exit:
 	mutex_exit(&async_tasks_mtx);
 	mutex_destroy(&async_tasks_mtx);
 
-	fprintf(stderr, "uzfs_zvol_mgmt_thread thread exiting\n");
+	LOG_DEBUG("uzfs_zvol_mgmt thread exiting");
 	zk_thread_exit();
 }

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -57,7 +57,7 @@ void zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...);
 #define	LOG_INFO(fmt, ...)	zrepl_log(LOG_LEVEL_INFO, fmt, ##__VA_ARGS__)
 #define	LOG_ERR(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, fmt, ##__VA_ARGS__)
 #define	LOG_ERRNO(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, \
-				    fmt ": ", ##__VA_ARGS__, strerror(errno))
+				    fmt ": %s", ##__VA_ARGS__, strerror(errno))
 
 SLIST_HEAD(zvol_list, zvol_info_s);
 extern kmutex_t zvol_list_mutex;

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -53,7 +53,11 @@ extern enum zrepl_log_level zrepl_log_level;
 void zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...);
 
 /* shortcuts to invoke log function with given log level */
-#define	LOG_DEBUG(fmt, ...)	zrepl_log(LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
+#define	LOG_DEBUG(fmt, ...)	\
+	do { \
+		if (unlikely(zrepl_log_level <= LOG_LEVEL_DEBUG)) \
+			zrepl_log(LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__); \
+	} while (0)
 #define	LOG_INFO(fmt, ...)	zrepl_log(LOG_LEVEL_INFO, fmt, ##__VA_ARGS__)
 #define	LOG_ERR(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, fmt, ##__VA_ARGS__)
 #define	LOG_ERRNO(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, \

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -25,8 +25,8 @@
 #ifndef	ZREPL_MGMT_H
 #define	ZREPL_MGMT_H
 
+#include <stdio.h>
 #include <pthread.h>
-#include <syslog.h>
 #include <sys/queue.h>
 #include <uzfs_io.h>
 #include "zrepl_prot.h"
@@ -42,6 +42,22 @@ extern "C" {
 
 #define	REBUILD_IO_SERVER_PORT	"3233"
 #define	IO_SERVER_PORT	"3232"
+
+enum zrepl_log_level {
+	LOG_LEVEL_DEBUG,
+	LOG_LEVEL_INFO,
+	LOG_LEVEL_ERR,
+};
+
+extern enum zrepl_log_level zrepl_log_level;
+void zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...);
+
+/* shortcuts to invoke log function with given log level */
+#define	LOG_DEBUG(fmt, ...)	zrepl_log(LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
+#define	LOG_INFO(fmt, ...)	zrepl_log(LOG_LEVEL_INFO, fmt, ##__VA_ARGS__)
+#define	LOG_ERR(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, fmt, ##__VA_ARGS__)
+#define	LOG_ERRNO(fmt, ...)	zrepl_log(LOG_LEVEL_ERR, \
+				    fmt ": ", ##__VA_ARGS__, strerror(errno))
 
 SLIST_HEAD(zvol_list, zvol_info_s);
 extern kmutex_t zvol_list_mutex;
@@ -136,24 +152,6 @@ void uzfs_zvol_store_last_committed_io_no(zvol_state_t *zv,
     uint64_t io_seq);
 extern int create_and_bind(const char *port, int bind_needed,
     boolean_t nonblocking);
-
-#define	ZREPL_LOG(fmt, ...)  syslog(LOG_NOTICE,				\
-		"%-18.18s:%4d: " fmt, __func__, __LINE__, ##__VA_ARGS__)
-
-#define	ZREPL_NOTICELOG(fmt, ...) syslog(LOG_NOTICE,			\
-		"%-18.18s:%4d: " fmt, __func__, __LINE__, ##__VA_ARGS__)
-
-#define	ZREPL_ERRLOG(fmt, ...) syslog(LOG_ERR,				\
-		"%-18.18s:%4d: " fmt, __func__, __LINE__, ##__VA_ARGS__)
-
-#define	ZREPL_WARNLOG(fmt, ...) syslog(LOG_ERR,				\
-		"%-18.18s:%4d: " fmt, __func__, __LINE__, ##__VA_ARGS__)
-
-#define	ZREPL_TRACELOG(FLAG, fmt, ...)					\
-	do {								\
-		syslog(LOG_NOTICE, "%-18.18s:%4d: "		\
-		    fmt, __func__, __LINE__, ##__VA_ARGS__);	\
-	} while (0)
 
 #ifdef	__cplusplus
 }

--- a/lib/libzpool/uzfs_mgmt.c
+++ b/lib/libzpool/uzfs_mgmt.c
@@ -467,13 +467,12 @@ uzfs_zvol_create_cb(const char *ds_name, void *arg)
 	char		*ip;
 
 	if (strrchr(ds_name, '@') != NULL) {
-		printf("no owning dataset for snapshots: %s\n", ds_name);
 		return (0);
 	}
 
 	error = uzfs_own_dataset(ds_name, &zv);
 	if (error) {
-		printf("Failed to open dataset: %s\n", ds_name);
+		/* happens normally for all non-zvol-type datasets */
 		return (error);
 	}
 
@@ -484,20 +483,19 @@ uzfs_zvol_create_cb(const char *ds_name, void *arg)
 			strncpy(zv->zv_target_host, ip,
 			    sizeof (zv->zv_target_host));
 		else {
-			printf("target IP address is not set for %s\n",
-			    ds_name);
+			LOG_ERR("target IP address is not set for %s", ds_name);
 			uzfs_close_dataset(zv);
 			return (error);
 		}
 	} else {
 		if (zv->zv_target_host[0] == '\0') {
-			printf("target IP address is NULL for %s\n", ds_name);
+			LOG_ERR("target IP address is empty for %s", ds_name);
 			uzfs_close_dataset(zv);
 			return (EINVAL);
 		}
 	}
 	if (uzfs_zinfo_init(zv, ds_name, nvprops) != 0) {
-		printf("Failed in uzfs_zinfo_init\n");
+		LOG_ERR("Failed in uzfs_zinfo_init");
 		return (error);
 	}
 
@@ -527,12 +525,7 @@ uzfs_zvol_create_minors(spa_t *spa, const char *name)
 int
 uzfs_zvol_destroy_cb(const char *ds_name, void *arg)
 {
-	if (ds_name)
-		printf("deleting ds_name %s\n", ds_name);
-	else
-		printf("deleting all dsnames on pool!\n ");
-	uzfs_zinfo_destroy(ds_name, arg);
-	return (0);
+	return (uzfs_zinfo_destroy(ds_name, arg));
 }
 
 /* disowns, closes dataset */

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -1,6 +1,5 @@
 #include <arpa/inet.h>
 #include <netdb.h>
-#include <syslog.h>
 #include <sys/zil.h>
 #include <sys/zfs_rlock.h>
 #include <sys/uzfs_zvol.h>
@@ -26,6 +25,54 @@ struct zvol_list stale_zv_list;
 	    (var) = (tvar))
 
 static int uzfs_zinfo_free(zvol_info_t *zinfo);
+
+enum zrepl_log_level zrepl_log_level;
+
+/*
+ * Log message to stdout/stderr if log level allows it.
+ */
+void
+zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
+{
+	va_list args;
+	struct timeval tv;
+	struct tm *timeinfo;
+	unsigned int ms;
+	char line[512];
+	FILE *outf;
+
+	if (lvl < zrepl_log_level)
+		return;
+
+	/* Create timestamp prefix */
+	gettimeofday(&tv, NULL);
+	timeinfo = localtime(&tv.tv_sec);
+	ms = tv.tv_usec / 1000;
+	strftime(line, sizeof (line), "%H:%M:%S.", timeinfo);
+	snprintf(line + 9, sizeof (line) - 9, "%03u", ms);
+
+	switch (lvl) {
+	case LOG_LEVEL_DEBUG:
+		outf = stdout;
+		strncpy(line + 12, " DEBUG ", sizeof (line) - 12);
+		break;
+	case LOG_LEVEL_INFO:
+		outf = stdout;
+		strncpy(line + 12, " INFO  ", sizeof (line) - 12);
+		break;
+	case LOG_LEVEL_ERR:
+		outf = stderr;
+		strncpy(line + 12, " ERROR ", sizeof (line) - 12);
+		break;
+	default:
+		ASSERT(0);
+	}
+
+	va_start(args, fmt);
+	vsprintf(line + 19, fmt, args);
+	va_end(args);
+	fprintf(outf, "%s\n", line);
+}
 
 int
 create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
@@ -59,8 +106,6 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 		}
 		s = bind(sfd, rp->ai_addr, rp->ai_addrlen);
 		if (s == 0) {
-			/* We managed to bind successfully! */
-			printf("bind is successful\n");
 			break;
 		}
 
@@ -68,7 +113,6 @@ create_and_bind(const char *port, int bind_needed, boolean_t nonblock)
 	}
 
 	if (rp == NULL) {
-		printf("bind failed with err\n");
 		return (-1);
 	}
 
@@ -115,7 +159,7 @@ uzfs_zinfo_take_refcnt(zvol_info_t *zinfo, int locked)
 static void
 uzfs_insert_zinfo_list(zvol_info_t *zinfo)
 {
-
+	LOG_INFO("Instantiating zvol %s", zinfo->name);
 	/* Base refcount is taken here */
 	(void) mutex_enter(&zvol_list_mutex);
 	uzfs_zinfo_take_refcnt(zinfo, B_TRUE);
@@ -126,7 +170,7 @@ uzfs_insert_zinfo_list(zvol_info_t *zinfo)
 static void
 uzfs_remove_zinfo_list(zvol_info_t *zinfo)
 {
-
+	LOG_INFO("Removing zvol %s", zinfo->name);
 	SLIST_REMOVE(&zvol_list, zinfo, zvol_info_s, zinfo_next);
 	(void) pthread_mutex_lock(&zinfo->zinfo_mutex);
 	zinfo->state = ZVOL_INFO_STATE_OFFLINE;
@@ -196,7 +240,6 @@ uzfs_zinfo_destroy_mutex(zvol_info_t *zinfo)
 int
 uzfs_zinfo_destroy(const char *name, spa_t *spa)
 {
-
 	zvol_info_t	*zinfo = NULL;
 	zvol_info_t    *zt = NULL;
 	int namelen = ((name) ? strlen(name) : 0);
@@ -215,13 +258,11 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			}
 		}
 	} else {
-
 		SLIST_FOREACH_SAFE(zinfo, &zvol_list, zinfo_next, zt) {
 			if (name == NULL || (strcmp(zinfo->name, name) == 0) ||
 			    ((strncmp(zinfo->name, name, namelen) == 0) &&
 			    zinfo->name[namelen] == '/' &&
 			    zinfo->name[namelen + 1] == '\0')) {
-				printf("destroying %s\n", zinfo->name);
 				zv = zinfo->zv;
 				uzfs_remove_zinfo_list(zinfo);
 				uzfs_close_dataset(zv);
@@ -229,10 +270,7 @@ uzfs_zinfo_destroy(const char *name, spa_t *spa)
 			}
 		}
 	}
-
-	(void) mutex_exit(&zvol_list_mutex);
-
-	printf("uzfs_zinfo_destroy path\n");
+	mutex_exit(&zvol_list_mutex);
 	return (0);
 }
 
@@ -263,7 +301,6 @@ uzfs_zinfo_init(void *zv, const char *ds_name, nvlist_t *create_props)
 	if (zinfo_create_hook)
 		(*zinfo_create_hook)(zinfo, create_props);
 
-	printf("uzfs_zinfo_init in success path\n");
 	return (0);
 }
 
@@ -276,7 +313,6 @@ uzfs_zinfo_free(zvol_info_t *zinfo)
 	taskq_destroy(zinfo->uzfs_zvol_taskq);
 	(void) uzfs_zinfo_destroy_mutex(zinfo);
 	ASSERT(STAILQ_EMPTY(&zinfo->complete_queue));
-	printf("Freeing volume =%s\n", zinfo->name);
 
 	free(zinfo);
 	return (0);

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -41,7 +41,7 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	char line[512];
 	FILE *outf;
 
-	if (lvl < zrepl_log_level)
+	if (likely(lvl < zrepl_log_level))
 		return;
 
 	/* Create timestamp prefix */
@@ -69,7 +69,7 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	}
 
 	va_start(args, fmt);
-	vsprintf(line + 19, fmt, args);
+	vsnprintf(line + 19, sizeof (line) - 19, fmt, args);
 	va_end(args);
 	fprintf(outf, "%s\n", line);
 }

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -41,7 +41,7 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	char line[512];
 	FILE *outf;
 
-	if (likely(lvl < zrepl_log_level))
+	if (lvl < zrepl_log_level)
 		return;
 
 	/* Create timestamp prefix */


### PR DESCRIPTION
and US1403 zrepl should stop logging IOs to syslog

The new logger is for zrepl layer which sits on top of uzfs. Internal zfs messages which are only few, are left intact in order to ease merges with upstream.

This is excellent opportunity to review all log messages in zrepl: content and log level. I already made some changes. Suggestions for adding new or removing existing ones are welcomed.

Example of output when running test suite:
```
16:16:35.114 INFO  auto importing pools by reading zpool.cache files failed to initialize libuzfs client
16:16:36.241 INFO  Instantiating zvol handshake/vol1
16:16:36.241 ERROR Failed to connect to 127.0.0.1:6060
16:16:40.254 INFO  Handshake on zvol handshake/vol1
16:16:44.294 ERROR Invalid replica protocol version 2
16:16:48.303 ERROR Unknown zvol: handshake/unknown
16:16:52.337 INFO  Removing zvol handshake/vol1 failed to initialize libuzfs client
16:16:52.390 INFO  auto importing pools by reading zpool.cache files
16:16:53.515 INFO  Instantiating zvol ihandshake/vol1
16:16:53.515 ERROR Failed to connect to 127.0.0.1:6060
16:16:57.536 INFO  Handshake on zvol ihandshake/vol1
16:16:57.557 INFO  auto importing pools by reading zpool.cache files failed to initialize libuzfs client
16:16:58.681 INFO  Instantiating zvol ihandshake/vol1
16:16:58.702 INFO  Handshake on zvol ihandshake/vol1
16:16:58.799 INFO  Instantiating zvol handshake/vol1
16:16:58.799 ERROR Failed to connect to 127.0.0.1:12345
16:17:02.807 ERROR Unknown zvol: ihandshake/vol1
16:17:02.854 INFO  Handshake on zvol handshake/vol1
...
```