### PR TITLE
Make uzfs with fio plugin compile on Ubuntu 17.10

### DIFF
--- a/lib/fio/Makefile.am
+++ b/lib/fio/Makefile.am
@@ -9,4 +9,4 @@ lib_LTLIBRARIES = replica.la
 replica_la_SOURCES = replica.c
 replica_la_LDFLAGS = -module
 # required for fio external plugins on linux
-replica_la_CFLAGS = -D_GNU_SOURCE -DCONFIG_STRSEP
+replica_la_CFLAGS = -D_GNU_SOURCE -DCONFIG_STRSEP -DCONFIG_PWRITEV2


### PR DESCRIPTION
In production we use Ubuntu 16.04 nevertheless it would be nice to support newer releases for developing cstor backend as well.