### PR TITLE
US1282 Decrease metadata writes

### DIFF
--- a/include/gtest_utils.h
+++ b/include/gtest_utils.h
@@ -13,10 +13,85 @@
 } while (0)
 
 namespace GtestUtils {
-	std::string execCmd(std::string const &zfsCmd, std::string const &args);
-	std::string getCmdPath(std::string zfsCmd);
-	int verify_buf(void *buf, int len, const char *pattern);
-	void init_buf(void *buf, int len, const char *pattern);
+
+std::string execCmd(std::string const &zfsCmd, std::string const &args);
+std::string getCmdPath(std::string zfsCmd);
+int verify_buf(void *buf, int len, const char *pattern);
+void init_buf(void *buf, int len, const char *pattern);
+
+/*
+ * Class which creates a vdev file in /tmp which can be used for pool creation.
+ * The file is automatically removed when vdev goes out of scope.
+ */
+class Vdev {
+public:
+	Vdev(std::string name) {
+		m_path = std::string("/tmp/") + name;
+	}
+
+	~Vdev() {
+		unlink(m_path.c_str());
+	}
+
+	void create();
+
+	std::string m_path;
+};
+
+/*
+ * Class simplifying test zfs pool creation and creation of zvols on it.
+ * Automatic pool destruction takes place when object goes out of scope.
+ */
+class TestPool {
+public:
+	TestPool(std::string poolname) {
+		m_name = poolname;
+		m_vdev = new Vdev(std::string("disk-for-") + poolname);
+	}
+
+	~TestPool() {
+		// try {
+			execCmd("zpool", std::string("destroy -f ") + m_name);
+		// } catch (std::runtime_error re) {
+			// ;
+		// }
+		delete m_vdev;
+	}
+
+	void create();
+	void import();
+	void createZvol(std::string name, std::string arg = "");
+	void destroyZvol(std::string name);
+	std::string getZvolName(std::string name);
+
+	Vdev *m_vdev;
+	std::string m_name;
+};
+
+/*
+ * zrepl program wrapper.
+ *
+ * The main benefits are:
+ *  1) when zrepl goes out of C++ scope it is automatically terminated,
+ *  2) special care is taken when starting and stopping the process to
+ *      make sure it is fully operation respectively fully terminated
+ *      to avoid various races.
+ */
+class Zrepl {
+public:
+	Zrepl() {
+		m_pid = 0;
+	}
+
+	~Zrepl() {
+		kill();
+	}
+
+	void start();
+	void kill();
+	pid_t m_pid;
+};
+
 }
 
 #endif	// _UZFS_UTILS_H

--- a/include/sys/fs/zfs.h
+++ b/include/sys/fs/zfs.h
@@ -393,7 +393,7 @@ typedef enum {
 } zfs_dnsize_type_t;
 
 typedef enum {
-	ZFS_REDUNDANT_METADATA_ALL,
+	ZFS_REDUNDANT_METADATA_NONE,
 	ZFS_REDUNDANT_METADATA_MOST
 } zfs_redundant_metadata_type_t;
 

--- a/module/zcommon/zfs_prop.c
+++ b/module/zcommon/zfs_prop.c
@@ -240,7 +240,7 @@ zfs_prop_init(void)
 	};
 
 	static zprop_index_t redundant_metadata_table[] = {
-		{ "all",	ZFS_REDUNDANT_METADATA_ALL },
+		{ "none",	ZFS_REDUNDANT_METADATA_NONE },
 		{ "most",	ZFS_REDUNDANT_METADATA_MOST },
 		{ NULL }
 	};
@@ -256,9 +256,9 @@ zfs_prop_init(void)
 
 	/* inherit index properties */
 	zprop_register_index(ZFS_PROP_REDUNDANT_METADATA, "redundant_metadata",
-	    ZFS_REDUNDANT_METADATA_ALL,
+	    ZFS_REDUNDANT_METADATA_NONE,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,
-	    "all | most", "REDUND_MD",
+	    "none | most", "REDUND_MD",
 	    redundant_metadata_table);
 	zprop_register_index(ZFS_PROP_SYNC, "sync", ZFS_SYNC_STANDARD,
 	    PROP_INHERIT, ZFS_TYPE_FILESYSTEM | ZFS_TYPE_VOLUME,

--- a/module/zfs/dmu.c
+++ b/module/zfs/dmu.c
@@ -1956,11 +1956,9 @@ dmu_write_policy(objset_t *os, dnode_t *dn, int level, int wp, zio_prop_t *zp)
 		    ZCHECKSUM_FLAG_EMBEDDED))
 			checksum = ZIO_CHECKSUM_FLETCHER_4;
 
-		if (os->os_redundant_metadata == ZFS_REDUNDANT_METADATA_ALL ||
-		    (os->os_redundant_metadata ==
-		    ZFS_REDUNDANT_METADATA_MOST &&
+		if (os->os_redundant_metadata == ZFS_REDUNDANT_METADATA_MOST &&
 		    (level >= zfs_redundant_metadata_most_ditto_level ||
-		    DMU_OT_IS_METADATA(type) || (wp & WP_SPILL))))
+		    DMU_OT_IS_METADATA(type) || (wp & WP_SPILL)))
 			copies++;
 	} else if (wp & WP_NOFILL) {
 		ASSERT(level == 0);

--- a/module/zfs/dmu_objset.c
+++ b/module/zfs/dmu_objset.c
@@ -273,7 +273,7 @@ redundant_metadata_changed_cb(void *arg, uint64_t newval)
 	/*
 	 * Inheritance and range checking should have been done by now.
 	 */
-	ASSERT(newval == ZFS_REDUNDANT_METADATA_ALL ||
+	ASSERT(newval == ZFS_REDUNDANT_METADATA_NONE ||
 	    newval == ZFS_REDUNDANT_METADATA_MOST);
 
 	os->os_redundant_metadata = newval;

--- a/tests/cbtest/gtest/Makefile.am
+++ b/tests/cbtest/gtest/Makefile.am
@@ -4,10 +4,11 @@ DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/lib/libspl/include
 
-sbin_PROGRAMS = test_uzfs test_zrepl_prot
+sbin_PROGRAMS = test_uzfs test_zfs test_zrepl_prot
 
 test_uzfs_SOURCES = test_uzfs.cc
 test_zrepl_prot_SOURCES = test_zrepl_prot.cc gtest_utils.cc
+test_zfs_SOURCES = test_zfs.cc gtest_utils.cc
 
 test_uzfs_LDADD = \
 	$(top_builddir)/lib/libnvpair/libnvpair.la \
@@ -19,3 +20,4 @@ test_uzfs_LDADD = \
 test_uzfs_CXXFLAGS = -std=c++11
 test_uzfs_LDFLAGS = -pthread -lgtest -lgtest_main
 test_zrepl_prot_LDFLAGS = -pthread -lgtest -lgtest_main
+test_zfs_LDFLAGS = -pthread -lgtest -lgtest_main

--- a/tests/cbtest/gtest/test_zfs.cc
+++ b/tests/cbtest/gtest/test_zfs.cc
@@ -1,0 +1,55 @@
+/*
+ * CDDL HEADER START
+ *
+ * The contents of this file are subject to the terms of the
+ * Common Development and Distribution License (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * You can obtain a copy of the license at usr/src/OPENSOLARIS.LICENSE
+ * or http://www.opensolaris.org/os/licensing.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * When distributing Covered Code, include this CDDL HEADER in each
+ * file and include the License file at usr/src/OPENSOLARIS.LICENSE.
+ * If applicable, add the following below this CDDL HEADER, with the
+ * fields enclosed by brackets "[]" replaced with your own identifying
+ * information: Portions Copyright [yyyy] [name of copyright owner]
+ *
+ * CDDL HEADER END
+ */
+/*
+ * Copyright (c) 2018 CloudByte, Inc. All rights reserved.
+ */
+
+/*
+ * Set of tests for testing zfs command. The tests here should not use library
+ * or network APIs, but rather just execute zfs/zpool commands.
+ */
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+#include <algorithm>
+
+#include "gtest_utils.h"
+
+using namespace GtestUtils;
+
+TEST(RedundantMetadata, NoneValue) {
+	std::string s;
+	Zrepl zrepl;
+	TestPool pool("redundantpool");
+	std::string zvol_name = pool.getZvolName("vol1");
+
+	zrepl.start();
+	pool.create();
+	pool.createZvol("vol1", "-o io.openebs:targetip=127.0.0.1");
+
+	s = execCmd("zfs", std::string("get -Ho value redundant_metadata ") + zvol_name);
+	// Trim white space at the end of string
+	s.erase(std::find_if(s.rbegin(), s.rend(),
+	    std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	EXPECT_STREQ(s.c_str(), "none");
+
+	execCmd("zfs", std::string("set redundant_metadata=none ") + zvol_name);
+}

--- a/tests/cbtest/script/test_uzfs.sh
+++ b/tests/cbtest/script/test_uzfs.sh
@@ -25,6 +25,7 @@ ZFS="$SRC_PATH/cmd/zfs/zfs"
 ZDB="$SRC_PATH/cmd/zdb/zdb"
 ZREPL="$SRC_PATH/cmd/zrepl/zrepl"
 GTEST_UZFS="$SRC_PATH/tests/cbtest/gtest/test_uzfs"
+GTEST_ZFS="$SRC_PATH/tests/cbtest/gtest/test_zfs"
 GTEST_ZREPL_PROT="$SRC_PATH/tests/cbtest/gtest/test_zrepl_prot"
 ZTEST="$SRC_PATH/cmd/ztest/ztest"
 UZFS_TEST="$SRC_PATH/cmd/uzfs_test/uzfs_test"
@@ -1187,6 +1188,7 @@ run_zvol_test()
 
 	stop_zrepl
 	log_must $GTEST_UZFS
+	log_must $GTEST_ZFS
 	log_must $GTEST_ZREPL_PROT
 	start_zrepl
 }


### PR DESCRIPTION
Replace redundant_metadata all value by none, which should be the new
default. We cannot extend the set of existing values (all and most),
because of compatibility reason.

Fix minor ref count leak on mgmt connection due to iscsi target quering
zvol which is not associated with mgmt connection.

Brief performance testing shows that iops increased by ~20% when measured
random read-write by fio compared to redundant_metadata=all. I haven't seen
much difference compared to redundant_metadata=most. That might have been
caused by relatively small size of zvol that I used for testing (7G).