### PR TITLE
US1886 Collect debug information from container when zrepl crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get clean && \
     apt-get update && \
     apt-get install -y apt-utils libaio1 libjemalloc1
 
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 COPY cmd/zrepl/.libs/zrepl /usr/local/bin/
 COPY cmd/zpool/.libs/zpool /usr/local/bin/
 COPY cmd/zfs/.libs/zfs /usr/local/bin/
@@ -28,5 +31,5 @@ LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 
-ENTRYPOINT ["/usr/local/bin/zrepl"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 EXPOSE 7676

--- a/README.markdown
+++ b/README.markdown
@@ -77,11 +77,15 @@ A docker image with zrepl *for testing purpose* can be built as follows.
 The privileged parameter when starting container is to enable process
 tracing inside the container. The last command gets you a shell inside
 the container which can be used for debugging, running zfs & zpool commands,
-etc.
+etc. Explanation of the two mounted volumes follows:
+
+ * /dev: All devices from host are visible inside the container so we can create pools on arbitrary block device.
+ * /tmp: This is a directory where core is dumped in case of a fatal failure. We make it persistent in order to preserve core dumps for later debugging.
 
 ```bash
 sudo docker build -t my-cstor .
-sudo docker run --privileged -it my-cstor
+sudo mkdir /tmp/cstor
+sudo docker run --privileged -it -v /dev:/dev --mount source=cstortmp,target=/tmp my-cstor
 sudo docker exec -it <container-id> /bin/bash
 ```
 

--- a/cmd/zrepl/Makefile.am
+++ b/cmd/zrepl/Makefile.am
@@ -3,6 +3,8 @@ include $(top_srcdir)/config/Rules.am
 # -Wnoformat-truncation to get rid of compiler warning for unchecked
 #  truncating snprintfs on gcc 7.1.1.
 AM_CFLAGS += $(FRAME_LARGER_THAN) $(NO_FORMAT_TRUNCATION)
+# Dynamic symbol table is needed for printing symbol names in stack trace
+AM_LDFLAGS = -rdynamic
 
 DEFAULT_INCLUDES += \
 	-I$(top_srcdir)/include \

--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -1,5 +1,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <execinfo.h>
 
 #include <libuzfs.h>
 #include <libzfs.h>
@@ -771,6 +772,54 @@ zrepl_svc_run(void)
 }
 
 /*
+ * Print a stack trace before program exits.
+ */
+void
+fatal_handler(int sig)
+{
+	void *array[20];
+	size_t size;
+
+	fprintf(stderr, "Fatal signal received: %d\n", sig);
+	fprintf(stderr, "Stack trace:\n");
+
+	size = backtrace(array, 20);
+	backtrace_symbols_fd(array, size, STDERR_FILENO);
+
+	/*
+	 * Hand over the sig for default processing to system to generate
+	 * a coredump
+	 */
+	signal(sig, SIG_DFL);
+	kill(getpid(), sig);
+}
+
+/*
+ * We would like to do a graceful shutdown here to avoid recovery actions
+ * when pool is imported next time. However we don't want to call export
+ * which does a bunch of other things which are not necessary (freeing
+ * memory resources etc.), since we run in userspace.
+ *
+ * mutex_enter(&spa_namespace_lock);
+ * while ((spa = spa_next(NULL)) != NULL) {
+ *	strlcpy(spaname, spa_name(spa), sizeof (spaname));
+ *	mutex_exit(&spa_namespace_lock);
+ *	LOG_INFO("Exporting pool %s", spaname);
+ *	spa_export(spaname, NULL, B_TRUE, B_FALSE);
+ *	mutex_enter(&spa_namespace_lock);
+ * }
+ * mutex_exit(&spa_namespace_lock);
+ *
+ * For now we keep it simple and just exit.
+ */
+void
+exit_handler(int sig)
+{
+	LOG_INFO("Caught SIGTERM. Exiting...");
+	exit(0);
+}
+
+/*
  * Main function for replica.
  */
 int
@@ -812,6 +861,11 @@ main(int argc, char **argv)
 
 	/* Ignore SIGPIPE signal */
 	signal(SIGPIPE, SIG_IGN);
+	signal(SIGTERM, exit_handler);
+	signal(SIGSEGV, fatal_handler);
+	signal(SIGBUS, fatal_handler);
+	signal(SIGILL, fatal_handler);
+
 	if (libuzfs_ioctl_init() < 0) {
 		LOG_ERR("Failed to initialize libuzfs ioctl");
 		goto initialize_error;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -o errexit
+
+# This relies on fact that /tmp is defined as k8s emptyDir volume
+echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
+ulimit -c unlimited
+
+exec /usr/local/bin/zrepl

--- a/module/zfs/zfs_ioctl.c
+++ b/module/zfs/zfs_ioctl.c
@@ -3469,7 +3469,8 @@ zfs_ioc_clone(const char *fsname, nvlist_t *innvl, nvlist_t *outnvl)
 		if (error != 0)
 			(void) dsl_destroy_head(fsname);
 #if !defined(_KERNEL)
-		(void) uzfs_zvol_create_cb(fsname, nvprops);
+		else
+			(void) uzfs_zvol_create_cb(fsname, nvprops);
 #endif
 	}
 	return (error);


### PR DESCRIPTION
Core dump support is more complicated and will not work in k8s env. Though it has been verified to work in local test env using docker image from zfs repo. We face two problems here:

1) Linux core_pattern is global and cannot be set independently for a cgroup. Very unlikely that this would get fixed, hence ...
2) people are investigating capability of piping core dumps to external program which can then do something with it based on k8s configuration: https://github.com/kubernetes/community/pull/1311 . This ticket seems stuck.

Core dump problem can be solved when either of the two problems mentioned above is solved. For now we have to be happy with just a stack from crashed zrepl.