### PR TITLE
US1923 Ability to change log level for replica

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -292,7 +292,7 @@ uzfs_zvol_rebuild_scanner_callback(off_t offset, size_t len,
 	hdr.len = len;
 	hdr.flags = ZVOL_OP_FLAG_REBUILD;
 	hdr.status = ZVOL_OP_STATUS_OK;
-	LOG_INFO("IO number for rebuild %ld", metadata->io_num);
+	LOG_DEBUG("IO number for rebuild %ld", metadata->io_num);
 	zio_cmd = zio_cmd_alloc(&hdr, warg->fd);
 	/* Take refcount for uzfs_zvol_worker to work on it */
 	uzfs_zinfo_take_refcnt(zinfo, B_FALSE);

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,7 @@ set -o errexit
 echo '/tmp/core.%h.%e.%t' > /proc/sys/kernel/core_pattern
 ulimit -c unlimited
 
-exec /usr/local/bin/zrepl
+if [ -z "$LOGLEVEL" ]; then
+	LOGLEVEL=info
+fi
+exec /usr/local/bin/zrepl -l $LOGLEVEL

--- a/lib/libzpool/kernel.c
+++ b/lib/libzpool/kernel.c
@@ -1527,7 +1527,7 @@ kernel_init(int mode)
 		fclose(f);
 	}
 
-	printf("physmem = %lu pages (%.2f GB)\n", physmem,
+	fprintf(stderr, "physmem = %lu pages (%.2f GB)\n", physmem,
 	    (double)physmem * sysconf(_SC_PAGE_SIZE) / (1ULL << 30));
 
 	(void) snprintf(hw_serial, sizeof (hw_serial), "%ld",

--- a/lib/libzpool/zrepl_mgmt.c
+++ b/lib/libzpool/zrepl_mgmt.c
@@ -38,7 +38,6 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	struct tm *timeinfo;
 	unsigned int ms;
 	char line[512];
-	FILE *outf;
 	int off = 0;
 
 	if (lvl < zrepl_log_level)
@@ -53,26 +52,15 @@ zrepl_log(enum zrepl_log_level lvl, const char *fmt, ...)
 	snprintf(line + off, sizeof (line) - off, "%03u ", ms);
 	off += 4;
 
-	switch (lvl) {
-	case LOG_LEVEL_DEBUG:
-		outf = stdout;
-		break;
-	case LOG_LEVEL_INFO:
-		outf = stdout;
-		break;
-	case LOG_LEVEL_ERR:
-		outf = stderr;
+	if (lvl == LOG_LEVEL_ERR) {
 		strncpy(line + off, "ERROR ", sizeof (line) - off);
 		off += sizeof ("ERROR ") - 1;
-		break;
-	default:
-		ASSERT(0);
 	}
 
 	va_start(args, fmt);
 	vsnprintf(line + off, sizeof (line) - off, fmt, args);
 	va_end(args);
-	fprintf(outf, "%s\n", line);
+	fprintf(stderr, "%s\n", line);
 }
 
 int


### PR DESCRIPTION
The goal was to be able to change log level without having to change the docker image. Currently the log level can be specified as parameter to zrepl, but parameters of zrepl are hardcoded in docker entrypoint script. This PR does not enable user to change the level for running zrepl and changing the level requires restart of the pod, but I consider this acceptable.

So we come up with more or less standard way of doing this in k8s world. Entrypoint script reads log level from environment and sets it when executing zrepl. The environment var is set by k8s based on configmap, which can be updated any time by the operator.

cstor-pool yaml deployment file must contain following section:
```
       envFrom:
        - configMapRef:
            name: cstor-pool-config
            optional: true
```
Config map can be easily created from command line by operator as follows:
```
kubectl create configmap cstor-pool-config --from-literal=LOGLEVEL=debug
```
If it already exists, the log level can be changed by editing the config map:
```
kubectl edit configmap cstor-pool-config
```
To see the contents of config map one could use:
```
kubectl describe configmap cstor-pool-config

Name:         cstor-pool-config
Namespace:    default
Labels:       <none>
Annotations:  <none>

Data
====
LOGLEVEL:
----
info
Events:  <none>
```
To restart the pod after changing log level:
```
kubectl delete pod cstor-pool-7f645554d7-9wxjm
```

Some other changes include:
 * Changing log levels for some of the messages.
 * Logging everything to stderr which has advantage over stdout that it is unbuffered.

I will be pushing some changes to cstor-pool yaml template in another repo to make this change complete.