### PR TITLE
Integrate with Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       only:
         - zfs-0.7-release
 jobs:
-  build:
+  build_tag_0:
     machine: 
       enabled: true
     environment:
@@ -54,3 +54,57 @@ jobs:
             export FIO_SRCDIR=$PWD/../fio;
             sudo -E bash ./tests/cbtest/script/test_uzfs.sh -T all || true;
             bash <(curl -s https://codecov.io/bash)
+  build_tag_1:
+    machine: 
+      enabled: true
+    working_directory: ~/github.com/openebs/zfs
+    steps:
+      - checkout
+      - run:
+          command: |    
+            sudo apt-get install git -y 
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update -qq
+            sudo apt-get install --yes -qq gcc-6 g++-6
+            sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
+            sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
+            sudo apt-get install --yes -qq lcov libjemalloc-dev
+            sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
+            sudo apt-get install --yes -qq libgtest-dev cmake
+            sudo apt-get install gdb
+            sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+            sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
+            pushd .
+            cd /usr/src/gtest
+            sudo cmake CMakeLists.txt
+            sudo make -j4
+            sudo cp *.a /usr/lib
+            popd
+            cd ..
+            git clone https://github.com/axboe/fio
+            cd fio
+            git checkout fio-3.7
+            ./configure
+            make -j4
+            cd ..
+            git clone https://github.com/openebs/spl
+            cd spl
+            git checkout spl-0.7.4
+            sh autogen.sh
+            ./configure
+            make --no-print-directory -s pkg-utils pkg-kmod;
+            sudo dpkg -i *.deb;
+            cd ../zfs
+            sh autogen.sh
+            ./configure --enable-code-coverage=yes --enable-debug || true;
+            make --no-print-directory -s pkg-utils pkg-kmod || true;
+            sudo dpkg -i *.deb || true;
+            make cstyle;
+            sudo modprobe zfs;
+            ztest || true;
+workflows:
+  version: 2
+  TAGS:
+    jobs:
+      - build_tag_0
+      - build_tag_1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,82 @@
+version: 2
+jobs:
+  build:
+    branches:
+      only:
+        - zfs-0.7-release
+  build:
+    docker:
+      - image: ubuntu:14.04
+    environment:
+      - ZFS_BUILD_TAGS=0
+      - CODECOV_TOKEN=04a04811-63ec-4800-b1d6-f741dc7e079a
+    working_directory: github.com/openebs/zfs
+    steps:
+      - checkout
+      - run:
+          command: |
+            # install dependencies
+            apt-get update
+            apt-get install bc
+            sudo apt-get install git -y
+            sudo apt-get install -y software-properties-common
+            sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
+            sudo apt-get update
+            sudo apt-get install gcc-snapshot -y
+            sudo apt-get update
+            sudo apt-get install gcc-6 g++-6 -y
+            sudo apt-get update
+            sudo apt-get install -y build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
+            sudo apt-get install -y zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
+            sudo apt-get install -y lcov libjemalloc-dev
+
+            # packages for tests
+            sudo apt-get install -y parted lsscsi ksh attr acl nfs-kernel-server fio
+            sudo apt-get install -y libgtest-dev cmake
+
+            # packages for debugging
+            sudo apt-get install -y gdb
+
+            # use gcc-6 by default
+            sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
+            sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
+            pushd .
+            cd /usr/src/gtest
+            sudo cmake CMakeLists.txt
+            sudo make -j4
+            sudo cp *.a /usr/lib
+            popd
+            cd ..
+
+            # we need fio repo to build zfs replica fio engine
+            git clone https://github.com/axboe/fio
+            cd fio
+
+            # TODO replace commit hash by version tag in future
+            git checkout 2e4ef4fbd69eb6d4c07f2f362463e3f3df2e808c
+            ./configure
+            make -j4
+            cd ..
+            git clone https://github.com/openebs/spl
+            cd spl
+            git checkout spl-0.7.4
+            sh autogen.sh
+            ./configure
+            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
+              make -j4;
+            fi
+            cd ../zfs
+            sh autogen.sh
+            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
+              ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio || true;
+              make -j4;
+            fi
+            make cstyle;
+             
+            # run ztest and test supported zio backends
+            # XXX enable the ztest when ticket #152 is fixed
+            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
+              export FIO_SRCDIR=$PWD/../fio;
+              timeout 60 sudo bash ./tests/cbtest/script/test_uzfs.sh -T all || true;
+            fi
+            bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,40 +4,27 @@ jobs:
     branches:
       only:
         - zfs-0.7-release
+jobs:
   build:
-    docker:
-      - image: ubuntu:14.04
+    machine: 
+      enabled: true
     environment:
-      - ZFS_BUILD_TAGS=0
       - CODECOV_TOKEN=04a04811-63ec-4800-b1d6-f741dc7e079a
-    working_directory: github.com/openebs/zfs
+    working_directory: ~/github.com/openebs/zfs
     steps:
       - checkout
       - run:
-          command: |
-            # install dependencies
-            apt-get update
-            apt-get install bc
-            sudo apt-get install git -y
-            sudo apt-get install -y software-properties-common
-            sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test
-            sudo apt-get update
-            sudo apt-get install gcc-snapshot -y
-            sudo apt-get update
-            sudo apt-get install gcc-6 g++-6 -y
-            sudo apt-get update
-            sudo apt-get install -y build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
-            sudo apt-get install -y zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
-            sudo apt-get install -y lcov libjemalloc-dev
-
-            # packages for tests
-            sudo apt-get install -y parted lsscsi ksh attr acl nfs-kernel-server fio
-            sudo apt-get install -y libgtest-dev cmake
-
-            # packages for debugging
-            sudo apt-get install -y gdb
-
-            # use gcc-6 by default
+          command: |    
+            sudo apt-get install git -y 
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            sudo apt-get update -qq
+            sudo apt-get install --yes -qq gcc-6 g++-6
+            sudo apt-get install --yes -qq build-essential autoconf libtool gawk alien fakeroot linux-headers-$(uname -r) libaio-dev
+            sudo apt-get install --yes -qq zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libssl-dev
+            sudo apt-get install --yes -qq lcov libjemalloc-dev
+            sudo apt-get install --yes -qq parted lsscsi ksh attr acl nfs-kernel-server fio
+            sudo apt-get install --yes -qq libgtest-dev cmake
+            sudo apt-get install gdb
             sudo unlink /usr/bin/gcc && sudo ln -s /usr/bin/gcc-6 /usr/bin/gcc
             sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-6 /usr/bin/g++
             pushd .
@@ -47,13 +34,9 @@ jobs:
             sudo cp *.a /usr/lib
             popd
             cd ..
-
-            # we need fio repo to build zfs replica fio engine
             git clone https://github.com/axboe/fio
             cd fio
-
-            # TODO replace commit hash by version tag in future
-            git checkout 2e4ef4fbd69eb6d4c07f2f362463e3f3df2e808c
+            git checkout fio-3.7
             ./configure
             make -j4
             cd ..
@@ -62,21 +45,12 @@ jobs:
             git checkout spl-0.7.4
             sh autogen.sh
             ./configure
-            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
-              make -j4;
-            fi
+            make -j4;
             cd ../zfs
             sh autogen.sh
-            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
-              ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio || true;
-              make -j4;
-            fi
+            ./configure --with-config=user --enable-code-coverage=yes --enable-debug --enable-uzfs=yes --with-jemalloc --with-fio=$PWD/../fio || true;
+            make -j4;
             make cstyle;
-             
-            # run ztest and test supported zio backends
-            # XXX enable the ztest when ticket #152 is fixed
-            if [ "$ZFS_BUILD_TAGS" = "0" ]; then
-              export FIO_SRCDIR=$PWD/../fio;
-              timeout 60 sudo bash ./tests/cbtest/script/test_uzfs.sh -T all || true;
-            fi
+            export FIO_SRCDIR=$PWD/../fio;
+            sudo -E bash ./tests/cbtest/script/test_uzfs.sh -T all || true;
             bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- Currently, when a commit happens, travis  gets triggered.
But, due to frequent issues with travis and other debugging issues with it, circleCI integration is needed.
- In Circle CI we have a time limit of 120mins for each build.
- Admin can ssh into the build and debug it and also after the build is completed the VM will be active for 30minutes for debugging .
- Due to kernel version issue only build will happen for build-tag-0.
- Deactivated Travis ci when PR is raised, when PR is raised CircleCI is triggered and when merged Travis is triggered. 



Signed-off-by: Pradeepkumarbk <pradeepkumar.bk96@gmail.com>

