### PR TITLE
[TA1143] Fix deadlock issue in finish_async_tasks.

### DIFF
--- a/cmd/zrepl/zrepl.c
+++ b/cmd/zrepl/zrepl.c
@@ -227,7 +227,7 @@ uzfs_zvol_io_receiver(void *arg)
 		    (hdr.opcode == ZVOL_OPCODE_READ)) && !hdr.len) {
 			LOG_ERR("Zero Payload size for opcode %d", hdr.opcode);
 			goto exit;
-		} else if (hdr.len > 0) {
+		} else if ((hdr.opcode == ZVOL_OPCODE_SYNC) && hdr.len > 0) {
 			LOG_ERR("Unexpected payload for opcode %d", hdr.opcode);
 			goto exit;
 		}

--- a/include/zrepl_mgmt.h
+++ b/include/zrepl_mgmt.h
@@ -84,6 +84,7 @@ typedef struct zvol_info_s {
 	int 		refcnt;
 	int		is_io_ack_sender_created;
 	uint32_t	timeout;	/* iSCSI timeout val for this zvol */
+	uint64_t	zvol_guid;
 	uint64_t	running_ionum;
 	uint64_t	checkpointed_ionum;
 	time_t		checkpointed_time;	/* time of the last chkpoint */
@@ -115,10 +116,12 @@ typedef struct zvol_info_s {
 	/* Perfromance counter */
 
 	/* Debug counters */
-	int 		read_req_received_cnt;
-	int 		write_req_received_cnt;
-	int 		read_req_ack_cnt;
-	int 		write_req_ack_cnt;
+	uint64_t 	read_req_received_cnt;
+	uint64_t 	write_req_received_cnt;
+	uint64_t 	sync_req_received_cnt;
+	uint64_t 	read_req_ack_cnt;
+	uint64_t	write_req_ack_cnt;
+	uint64_t	sync_req_ack_cnt;
 
 	/* ongoing command that is being worked on to ack to its sender */
 	void		*zio_cmd_in_ack;

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -497,6 +497,8 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	 */
 	mgmt_ack.zvol_guid = dsl_dataset_phys(
 	    zv->zv_objset->os_dsl_dataset)->ds_guid;
+	zinfo->zvol_guid = mgmt_ack.zvol_guid;
+	LOG_INFO("Volume:%s has zvol_guid:%lu", zinfo->name, zinfo->zvol_guid);
 
 	bzero(&hdr, sizeof (hdr));
 	hdr.version = REPLICA_VERSION;
@@ -593,9 +595,8 @@ finish_async_tasks(void)
 			rc = reply_nodata(async_task->conn, async_task->status,
 			    async_task->hdr.opcode, async_task->hdr.io_seq);
 		}
+
 		free_async_task(async_task);
-		if (rc != 0)
-			return (rc);
 	}
 	mutex_exit(&async_tasks_mtx);
 	return (0);

--- a/lib/libzrepl/mgmt_conn.c
+++ b/lib/libzrepl/mgmt_conn.c
@@ -497,7 +497,8 @@ uzfs_zvol_mgmt_do_handshake(uzfs_mgmt_conn_t *conn, zvol_io_hdr_t *hdrp,
 	 */
 	mgmt_ack.zvol_guid = dsl_dataset_phys(
 	    zv->zv_objset->os_dsl_dataset)->ds_guid;
-	zinfo->zvol_guid = mgmt_ack.zvol_guid;
+	if (zinfo->zvol_guid == 0)
+		zinfo->zvol_guid = mgmt_ack.zvol_guid;
 	LOG_INFO("Volume:%s has zvol_guid:%lu", zinfo->name, zinfo->zvol_guid);
 
 	bzero(&hdr, sizeof (hdr));
@@ -595,11 +596,12 @@ finish_async_tasks(void)
 			rc = reply_nodata(async_task->conn, async_task->status,
 			    async_task->hdr.opcode, async_task->hdr.io_seq);
 		}
-
 		free_async_task(async_task);
+		if (rc == -1)
+			break;
 	}
 	mutex_exit(&async_tasks_mtx);
-	return (0);
+	return (rc);
 }
 
 /*


### PR DESCRIPTION
Fixed, deadlock issue in finish_async_tasks(). In error case, we were returning without releasing lock. Now we do not return even if there is error on that particular connection.

Some other minor fixes are...
1. Use GUID of volume for naming threads in uzfs_zvol_io_receiver() & uzfs_zvol_io_ack_sender().
2. uzfs_zvol_io_receiver(), should check hdr->len for read and write and error out if hdr->len is zero for read/write.
3. uzfs_zvol_worker() & uzfs_zvol_io_ack_sender(), zinfo counters need to be updated properly, as of today, all other opcode except writes are treated as read.
4. uzfs_zvol_io_ack_sender(), should use SHUTDOWN(fd) before closing fd.
5. Better to log thread exit with GUID so that we know which thread(related to which replica got exited).

Signed-off-by: satbir <satbir.chhikara@gmail.com>

